### PR TITLE
adding support for OSX 10.5 and 10.6

### DIFF
--- a/lib/chef/knife/prepare.rb
+++ b/lib/chef/knife/prepare.rb
@@ -1,6 +1,7 @@
 require 'chef/knife'
 require 'knife-solo/ssh_command'
 require 'knife-solo/kitchen_command'
+require 'knife-solo/bootstraps'
 
 class Chef
   class Knife
@@ -14,8 +15,12 @@ class Chef
 
       def run
         super
-        send("#{distro[:type]}_install")
+        bootstrap.bootstrap!
         generate_node_config
+      end
+
+      def bootstrap
+        KnifeSolo::Bootstraps.class_for_operating_system(operating_system()).new(self)
       end
 
       def generate_node_config
@@ -26,106 +31,14 @@ class Chef
         end unless node_config.exist?
       end
 
-      def package_list
-        @packages.join(' ')
+      def operating_system
+        @operating_system ||= begin
+                                run_command('uname -s').stdout.strip
+                              rescue
+                                ""
+                              end
       end
 
-      def zypper_gem_install
-        ui.msg("Installing required packages...")
-        run_command("sudo zypper --non-interactive install ruby-devel make gcc rsync")
-        gem_install
-      end
-
-      def emerge_gem_install
-        ui.msg("Installing required packages...")
-        run_command("sudo USE='-test' ACCEPT_KEYWORDS='~amd64' emerge -u chef")
-      end
-
-      def add_yum_repos
-        repo_url = "http://rbel.co/"
-        if distro[:version] == "RHEL5"
-          repo_path = "/rbel5"
-        else
-          repo_path = "/rbel6"
-        end
-        installed = "is already installed"
-        result = run_command("#{sudo} rpm -Uvh #{repo_url}#{repo_path}")
-        raise result.stderr_or_stdout unless result.success? || result.stdout.match(installed)
-      end
-
-      def yum_install
-        ui.msg("Installing required packages...")
-        add_yum_repos
-        @packages = %w(rubygem-chef rsync)
-        run_command("#{sudo} yum -y install #{package_list}")
-      end
-
-      def debian_gem_install
-        ui.msg "Updating apt caches..."
-        run_command("sudo apt-get update")
-
-        ui.msg "Installing required packages..."
-        @packages = %w(ruby ruby-dev libopenssl-ruby irb
-                       build-essential wget ssl-cert rsync)
-        run_command <<-BASH
-          sudo DEBIAN_FRONTEND=noninteractive apt-get --yes install #{package_list}
-        BASH
-
-        gem_install
-      end
-
-      def gem_install
-        ui.msg "Installing rubygems from source..."
-        release = "rubygems-1.8.10"
-        file = "#{release}.tgz"
-        url = "http://production.cf.rubygems.org/rubygems/#{file}"
-        run_command("wget #{url}")
-        run_command("tar zxf #{file}")
-        run_command("cd #{release} && sudo ruby setup.rb --no-format-executable")
-        run_command("sudo rm -rf #{release} #{file}")
-        run_command("sudo gem install --no-rdoc --no-ri ruby-shadow chef")
-      end
-
-      def issue
-        run_command("cat /etc/issue").stdout
-      end
-
-      def distro
-        return @distro if @distro
-        @distro = case issue
-        when %r{Debian GNU/Linux 5}
-          {:type => "debian_gem", :version => "lenny"}
-        when %r{Debian GNU/Linux 6}
-          {:type => "debian_gem", :version => "squeeze"}
-        when %r{Debian GNU/Linux wheezy}
-          {:type => "debian_gem", :version => "wheezy"}
-        when %r{Ubuntu}
-          version = run_command("lsb_release -cs").stdout.strip
-          {:type => "debian_gem", :version => version}
-        when %r{CentOS.*? 5}
-          {:type => "yum", :version => "RHEL5"}
-        when %r{CentOS.*? 6}
-          {:type => "yum", :version => "RHEL6"}
-        when %r{Red Hat Enterprise.*? 5}
-          {:type => "yum", :version => "RHEL5"}
-        when %r{Red Hat Enterprise.*? 6}
-          {:type => "yum", :version => "RHEL6"}
-        when %r{Scientific Linux.*? 5}
-          {:type => "yum", :version => "RHEL5"}
-        when %r{Scientific Linux.*? 6}
-          {:type => "yum", :version => "RHEL6"}
-        when %r{SUSE Linux Enterprise Server 11 SP1}
-          {:type => "zypper_gem", :version => "SLES11"}
-        when %r{openSUSE 11.4}
-          {:type => "zypper_gem", :version => "openSUSE"}
-        when %r{This is \\n\.\\O (\\s \\m \\r) \\t}
-          {:type => "gentoo_gem", :version => "Gentoo"}
-        else
-          raise "Distro not recognized from looking at /etc/issue. Please fork https://github.com/matschaffer/knife-solo and add support for your distro."
-        end
-        Chef::Log.debug("Distro detection yielded: #{@distro}")
-        @distro
-      end
     end
   end
 end

--- a/lib/knife-solo/bootstraps.rb
+++ b/lib/knife-solo/bootstraps.rb
@@ -1,0 +1,90 @@
+class OperatingSystemNotSupportedError < StandardError ; end
+
+module KnifeSolo
+  module Bootstraps
+    class OperatingSystemNotImplementedError < StandardError 
+    end
+
+    def self.class_exists_for?(os_name)
+      begin
+        true if self.class_for_operating_system(os_name).class == Class
+      rescue => exception
+        false
+      end
+    end
+
+    def self.class_for_operating_system(os_name)
+      begin
+        os_class_name = os_name.gsub(/\s/,'')
+        eval("KnifeSolo::Bootstraps::#{os_class_name}")
+      rescue
+        raise OperatingSystemNotImplementedError.new("#{os_name} not implemented.  Feel free to add a bootstrap implementation in KnifeSolo::Bootstraps::#{os_class_name}")
+      end
+    end
+
+    module Delegates
+      def run_command(cmd)
+        prepare.run_command(cmd)
+      end
+
+      def ui
+        prepare.ui
+      end
+
+      def prepare
+        @prepare
+      end
+    end #Delegates
+
+    module InstallCommands
+
+      def bootstrap!
+        run_pre_bootstrap_checks()
+        send("#{distro[:type]}_install")
+      end
+
+      def distro
+        raise "implement distro detection for #{self.class.name}"
+      end
+
+      def gem_packages
+        raise "implement gem packages for #{self.class.name}"
+      end
+
+      def http_client_get_url(url)
+        "wget #{url}"
+      end
+
+      def gem_install
+        ui.msg "Installing rubygems from source..."
+        release = "rubygems-1.8.10"
+        file = "#{release}.tgz"
+        url = "http://production.cf.rubygems.org/rubygems/#{file}"
+        run_command(http_client_get_url(url))
+        run_command("tar zxf #{file}")
+        run_command("cd #{release} && sudo ruby setup.rb --no-format-executable")
+        run_command("sudo rm -rf #{release} #{file}")
+        run_command("sudo gem install --no-rdoc --no-ri #{gem_packages().join(' ')}")
+      end
+    end #InstallCommands
+
+    class Base
+      include KnifeSolo::Bootstraps::Delegates
+      include KnifeSolo::Bootstraps::InstallCommands
+
+      def initialize(prepare)
+        # instance of Chef::Knife::Prepare
+        @prepare = prepare
+      end
+
+      def run_pre_bootstrap_checks ; end
+      # run right before we run #{distro[:type]}_install method
+      # barf out here if need be
+    end
+    
+  end # Bootstraps
+end
+
+
+# bootstrap classes for different OSes
+Dir[File.dirname(__FILE__) + '/bootstraps/*.rb'].each {|p| require p}

--- a/lib/knife-solo/bootstraps/darwin.rb
+++ b/lib/knife-solo/bootstraps/darwin.rb
@@ -1,0 +1,38 @@
+module KnifeSolo::Bootstraps
+  class Darwin < Base
+
+    def issue
+      run_command("sw_vers -productVersion").stdout.strip
+    end
+
+    def gem_packages
+      ['chef']
+    end
+    
+    def distro
+      case issue
+      when %r{10.5}
+          {:type => 'gem', :version => 'leopard'}
+      when %r{10.6}
+          {:type => 'gem', :version => 'snow_leopard'}
+      else
+          raise "OSX version #{issue} not supported"
+      end
+    end
+
+    def has_xcode_installed?
+      result = run_command("xcodebuild -version")
+      result.success?
+    end
+
+    def http_client_get_url(url)
+      filename = url.split("/").last
+      "curl '#{url}' >> #{filename}"
+    end
+
+    def run_pre_bootstrap_checks
+      raise 'xcode not installed, which is required to do anything.  please install and run again.' unless has_xcode_installed?
+    end
+
+  end
+end

--- a/lib/knife-solo/bootstraps/linux.rb
+++ b/lib/knife-solo/bootstraps/linux.rb
@@ -1,0 +1,102 @@
+module KnifeSolo::Bootstraps
+  class Linux < Base
+
+    def issue
+      prepare.run_command("cat /etc/issue").stdout.strip
+    end
+
+    def package_list
+      @packages.join(' ')
+    end
+
+    def gem_packages
+      ['ruby-shadow','chef']
+    end
+
+    def http_client_get_url(url)
+      "wget #{url}"
+    end
+
+    def zypper_gem_install
+      ui.msg("Installing required packages...")
+      run_command("sudo zypper --non-interactive install ruby-devel make gcc rsync")
+      gem_install
+    end
+
+    def emerge_gem_install
+      ui.msg("Installing required packages...")
+      run_command("sudo USE='-test' ACCEPT_KEYWORDS='~amd64' emerge -u chef")
+    end
+
+    def add_yum_repos
+      repo_url = "http://rbel.co/"
+      if distro[:version] == "RHEL5"
+        repo_path = "/rbel5"
+      else
+        repo_path = "/rbel6"
+      end
+      installed = "is already installed"
+      result = run_command("#{sudo} rpm -Uvh #{repo_url}#{repo_path}")
+      raise result.stderr_or_stdout unless result.success? || result.stdout.match(installed)
+    end
+
+    def yum_install
+      ui.msg("Installing required packages...")
+      add_yum_repos
+      @packages = %w(rubygem-chef rsync)
+      run_command("#{sudo} yum -y install #{package_list}")
+    end
+
+    def debian_gem_install
+      ui.msg "Updating apt caches..."
+      run_command("sudo apt-get update")
+
+      ui.msg "Installing required packages..."
+      @packages = %w(ruby ruby-dev libopenssl-ruby irb
+                     build-essential wget ssl-cert rsync)
+      run_command <<-BASH
+        sudo DEBIAN_FRONTEND=noninteractive apt-get --yes install #{package_list}
+      BASH
+
+      gem_install
+    end
+
+    def distro
+      return @distro if @distro
+      @distro = case issue
+      when %r{Debian GNU/Linux 5}
+        {:type => "debian_gem", :version => "lenny"}
+      when %r{Debian GNU/Linux 6}
+        {:type => "debian_gem", :version => "squeeze"}
+      when %r{Debian GNU/Linux wheezy}
+        {:type => "debian_gem", :version => "wheezy"}
+      when %r{Ubuntu}
+        version = run_command("lsb_release -cs").stdout.strip
+        {:type => "debian_gem", :version => version}
+      when %r{CentOS.*? 5}
+        {:type => "yum", :version => "RHEL5"}
+      when %r{CentOS.*? 6}
+        {:type => "yum", :version => "RHEL6"}
+      when %r{Red Hat Enterprise.*? 5}
+        {:type => "yum", :version => "RHEL5"}
+      when %r{Red Hat Enterprise.*? 6}
+        {:type => "yum", :version => "RHEL6"}
+      when %r{Scientific Linux.*? 5}
+        {:type => "yum", :version => "RHEL5"}
+      when %r{Scientific Linux.*? 6}
+        {:type => "yum", :version => "RHEL6"}
+      when %r{SUSE Linux Enterprise Server 11 SP1}
+        {:type => "zypper_gem", :version => "SLES11"}
+      when %r{openSUSE 11.4}
+        {:type => "zypper_gem", :version => "openSUSE"}
+      when %r{This is \\n\.\\O (\\s \\m \\r) \\t}
+        {:type => "gentoo_gem", :version => "Gentoo"}
+      else
+        raise "Distro not recognized from looking at /etc/issue. Please fork https://github.com/matschaffer/knife-solo and add support for your distro."
+      end
+      Chef::Log.debug("Distro detection yielded: #{@distro}")
+      @distro
+    end #issue
+
+  end
+end

--- a/lib/knife-solo/kitchen_command.rb
+++ b/lib/knife-solo/kitchen_command.rb
@@ -11,8 +11,11 @@ module KnifeSolo
     end
 
     def run
-      all_present  = required_files.inject(true) { |m, f| m && File.exists?(f) }
-      raise OutOfKitchenError.new unless all_present
+      raise OutOfKitchenError.new unless required_files_present?
+    end
+
+    def required_files_present?
+      required_files.inject(true) { |m, f| m && File.exists?(f) }
     end
   end
 end

--- a/test/bootstraps_test.rb
+++ b/test/bootstraps_test.rb
@@ -1,0 +1,81 @@
+require 'test_helper'
+
+require 'knife-solo/bootstraps'
+
+class KnifeSolo::Bootstraps::StubOS < KnifeSolo::Bootstraps::Base
+end
+
+class KnifeSolo::Bootstraps::StubOS2 < KnifeSolo::Bootstraps::Base
+  def gem_packages ; ['chef'] ; end
+  def distro ; {:type => 'gem', :version => 'Fanny Faker'} ; end
+  def gem_install 
+    # dont' actually install anything 
+  end
+end
+
+class BootstrapsTest < TestCase
+  def test_bootstrap_class_exists_for
+    assert_equal true, KnifeSolo::Bootstraps.class_exists_for?('Stub OS')
+
+    assert_equal false, KnifeSolo::Bootstraps.class_exists_for?('Mythical OS')
+  end
+
+  def test_distro_raises_if_not_implemented
+    bootstrap = bootstrap_instance() 
+
+    assert_raise RuntimeError do
+      bootstrap.distro()
+    end
+  end
+
+  def test_gem_packages_raises_if_not_implemented
+    bootstrap = bootstrap_instance() 
+
+    assert_raise RuntimeError do
+      bootstrap.gem_packages()
+    end
+  end
+
+  def test_bootstrap_calls_appropriate_install_method
+    bootstrap = KnifeSolo::Bootstraps::StubOS2.new(mock)
+    bootstrap.stubs(:distro).returns({:type => 'disco_gem'})
+
+    bootstrap.expects(:disco_gem_install)
+
+    bootstrap.bootstrap!
+  end
+
+  def test_bootstrap_calls_pre_bootstrap_checks
+    bootstrap = KnifeSolo::Bootstraps::StubOS2.new(mock)
+
+    bootstrap.expects(:run_pre_bootstrap_checks)
+
+    bootstrap.bootstrap!
+  end
+
+  def test_bootstrap_delegates_to_knife_prepare
+    prepare = mock('chef::knife::prepare')
+    bootstrap = KnifeSolo::Bootstraps::StubOS2.new(prepare)
+
+    assert prepare == bootstrap.prepare
+  end
+
+  def test_darwin_checks_for_xcode_install_and_barfs_if_missing
+    bootstrap = KnifeSolo::Bootstraps::Darwin.new(mock)
+    # don't want to actually run anything
+    bootstrap.stubs(:gem_install)
+
+    bootstrap.expects(:has_xcode_installed?).returns(false)
+
+    assert_raise RuntimeError do
+      bootstrap.bootstrap!
+    end
+  end
+
+  # ***
+
+  def bootstrap_instance
+    @prepare = mock('Knife::Chef::Prepare')
+    KnifeSolo::Bootstraps::StubOS.new(@prepare)
+  end
+end

--- a/test/prepare_test.rb
+++ b/test/prepare_test.rb
@@ -30,6 +30,33 @@ class PrepareTest < TestCase
     end
   end
 
+  def test_run_raises_if_operating_system_is_not_supported
+    Dir.chdir("/tmp") do
+      FileUtils.mkdir("nodes")
+      run_command = command("somehost")
+      run_command.stubs(:required_files_present?).returns(true)
+      run_command.stubs(:operating_system).returns('MythicalOS')
+      assert_raise KnifeSolo::Bootstraps::OperatingSystemNotImplementedError do
+        run_command.run
+      end
+    end
+  end
+
+  def test_run_calls_bootstrap
+    Dir.chdir("/tmp") do
+      FileUtils.mkdir("nodes")
+      run_command = command("somehost")
+      bootstrap_instance = mock('mock OS bootstrap instance')
+      run_command.stubs(:required_files_present?).returns(true)
+      run_command.stubs(:operating_system).returns('MythicalOS')
+      run_command.stubs(:bootstrap).returns(bootstrap_instance)
+
+      bootstrap_instance.expects(:bootstrap!)
+
+      run_command.run
+    end
+  end
+
   def teardown
     FileUtils.rm_r("/tmp/nodes")
   end


### PR DESCRIPTION
still requires 10.5 and 10.6 machines have XCode installed

did a good chunk of refactoring around
the initial chef bootstrapping that was happening in lib/chef/knife/prepare.rb
- added KnifeSolo::Bootstraps with an eye toward keeping OS specific
  bootstrap jawns in different classes
- OS specific bootstraps inherit from KnifeSolo::Bootstraps::Base

Really, really awesome project, Mat.  If you find this code acceptable, I'd love to contribute.
