### PR TITLE
Add --skip-chef-check knife option (supports omnibus installer).

### DIFF
--- a/lib/chef/knife/cook.rb
+++ b/lib/chef/knife/cook.rb
@@ -16,11 +16,16 @@ class Chef
 
       banner "knife cook [user@]hostname [json] (options)"
 
+      option :skip_chef_check,
+        :long => '--skip-chef-check',
+        :boolean => true,
+        :description => "Skip the version check on the Chef gem"
+
       def run
         super
         check_syntax
         Chef::Config.from_file('solo.rb')
-        check_chef_version
+        check_chef_version unless config[:skip_chef_check]
         rsync_kitchen
         add_patches
         cook


### PR DESCRIPTION
Hi there,

When I set up a node using Chef's [omnibus installer](http://www.opscode.com/chef/install/), the gem version checking was failing. That makes sense since there really isn't a `bin/ruby` to be found in PATH. One alternative solution would be to capture and parse the result from `chef-solo --version` although that's not so pretty. This sidesteps the issue, but it works!
