### PR TITLE
Make the rsync command less verbose

### DIFF
--- a/lib/chef/knife/cook.rb
+++ b/lib/chef/knife/cook.rb
@@ -62,13 +62,13 @@ class Chef
       end
 
       def rsync_kitchen
-        system %Q{rsync -rlP --rsh="ssh #{ssh_args}" --delete --exclude '.*' ./ :#{chef_path}}
+        system %Q{rsync -rl --rsh="ssh #{ssh_args}" --delete --exclude '.*' ./ :#{chef_path}}
       end
 
       def add_patches
         run_command "mkdir -p #{patch_path}"
         Dir[Pathname.new(__FILE__).dirname.join("patches", "*.rb")].each do |patch|
-          system %Q{rsync -rlP --rsh="ssh #{ssh_args}" #{patch} :#{patch_path}}
+          system %Q{rsync -rl --rsh="ssh #{ssh_args}" #{patch} :#{patch_path}}
         end
       end
 


### PR DESCRIPTION
It would be nice if the rsync didn't include the -P switch, since that makes it output multiple screens of data that I don't care about every time I do a knife cook.

Can we change:

``` ruby
      def rsync_kitchen
        system %Q{rsync -rlP --rsh="ssh #{ssh_args}" --delete --exclude '.*' ./ :#{chef_path}}
      end
```

to:

``` ruby
      def rsync_kitchen
        system %Q{rsync -rl --rsh="ssh #{ssh_args}" --delete --exclude '.*' ./ :#{chef_path}}
      end
```

or provide a way to configure which options rsync uses, like :rsync_options => '-rl' to override the default?
