### PR TITLE
Add --skip-syntax-check knife option.

### DIFF
--- a/lib/chef/knife/cook.rb
+++ b/lib/chef/knife/cook.rb
@@ -21,9 +21,14 @@ class Chef
         :boolean => true,
         :description => "Skip the version check on the Chef gem"
 
+      option :skip_syntax_check,
+        :long => '--skip-syntax-check',
+        :boolean => true,
+        :description => "Skip Ruby syntax checks"
+
       def run
         super
-        check_syntax
+        check_syntax unless config[:skip_syntax_check]
         Chef::Config.from_file('solo.rb')
         check_chef_version unless config[:skip_chef_check]
         rsync_kitchen


### PR DESCRIPTION
Hey,

This is mostly a speed-up option for Chef repos containing upstream/production cookbooks. That is, once the cookbooks have been vetted, deploy away!

Cheers!
