### PR TITLE
--exclude options for rsync

### DIFF
--- a/lib/chef/knife/cook.rb
+++ b/lib/chef/knife/cook.rb
@@ -80,7 +80,7 @@ class Chef
       end
 
       def rsync_kitchen
-        system! %Q{rsync -rl --rsh="ssh #{ssh_args}" --delete --exclude '.*' ./ :#{adjust_rsync_path(chef_path)}}
+        system! %Q{rsync -rl --rsh="ssh #{ssh_args}" --delete --exclude revision-deploys --exclude tmp --exclude '.*' ./ :#{adjust_rsync_path(chef_path)}}
       end
 
       def add_patches


### PR DESCRIPTION
Added --exclude revision-deploys to rsync command so that it doesn't try to wipe out the #{chef_path}/revision-deploys directory used by the deploy_revision resource.

Added --exclude tmp to rsync command so that it doesn't waste time and
bandwidth transferring the tmp/ directory that is generated by
librarian-chef (and unneeded since librarian-chef transfers the actual
cookbooks to the cookbooks/ dir).
