### PR TITLE
Fix sudo usage in rubygems installation

### DIFF
--- a/lib/knife-solo/bootstraps.rb
+++ b/lib/knife-solo/bootstraps.rb
@@ -67,7 +67,8 @@ module KnifeSolo
         url = "http://production.cf.rubygems.org/rubygems/#{file}"
         run_command(http_client_get_url(url))
         run_command("tar zxf #{file}")
-        run_command("cd #{release} && sudo ruby setup.rb --no-format-executable")
+        run_command("cd #{release}")
+        run_command("sudo ruby setup.rb --no-format-executable")
         run_command("sudo rm -rf #{release} #{file}")
         run_command("sudo gem install --no-rdoc --no-ri #{gem_packages().join(' ')}")
       end


### PR DESCRIPTION
Hello,

While running 'knife prepare' on a Debian server, one command was not modified to run 'knife sudo' instead of 'sudo'.

I went for the easy fix, but the process_sudo regexp could be updated to fix future usage.
