### PR TITLE
fixes error when trying to run rubygems/setup.rb

### DIFF
--- a/lib/knife-solo/bootstraps.rb
+++ b/lib/knife-solo/bootstraps.rb
@@ -67,7 +67,7 @@ module KnifeSolo
         url = "http://production.cf.rubygems.org/rubygems/#{file}"
         run_command(http_client_get_url(url))
         run_command("tar zxf #{file}")
-        run_command("cd #{release} && sudo ruby setup.rb --no-format-executable")
+        run_command("sudo ruby #{release}/setup.rb --no-format-executable")
         run_command("sudo rm -rf #{release} #{file}")
         run_command("sudo gem install --no-rdoc --no-ri #{gem_packages().join(' ')}")
       end


### PR DESCRIPTION
The fix (https://github.com/matschaffer/knife-solo/pull/49) from @Geal did not work from me.  It still fails to cd to the rubygems directory and does not install.  This commit fixes the error by specifying the path of the setup.rb file instead of changing to the directory.
