### PR TITLE
Uses sudo by default when calling chef solo.

### DIFF
--- a/lib/chef/knife/cook.rb
+++ b/lib/chef/knife/cook.rb
@@ -120,7 +120,7 @@ class Chef
         logging_arg = "-l debug" if config[:verbosity] > 0
 
         stream_command <<-BASH
-          chef-solo -c #{chef_path}/solo.rb \
+          sudo chef-solo -c #{chef_path}/solo.rb \
                          -j #{chef_path}/#{node_config} \
                          #{logging_arg}
         BASH


### PR DESCRIPTION
This might not be the best way to handle this. Perhaps we should only use sudo when user is not root. We can check the distrib_id if this is a debian/ubuntu specific issue.
