### PR TITLE
Net-ssh dependency compatible with chef-0.10.10

### DIFF
--- a/knife-solo.gemspec
+++ b/knife-solo.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'mocha'
 
   s.add_dependency 'chef',    '~> 0.10.0'
-  s.add_dependency 'net-ssh', '~> 2.1.3'
+  s.add_dependency 'net-ssh', '>= 2.1.3', '< 2.3.0'
 
   s.files = Dir['lib/**/*']
 


### PR DESCRIPTION
chef-0.10.10 requires net-ssh ~> 2.2.2, which is out of ~>2.1.3
