### PR TITLE
Changing 'knife cook' to look for greater than or equal to Chef 0.10.4. Closes #55

### DIFF
--- a/lib/chef/knife/cook.rb
+++ b/lib/chef/knife/cook.rb
@@ -100,7 +100,7 @@ class Chef
       end
 
       def check_chef_version
-        constraint = "~>0.10.4"
+        constraint = ">=0.10.4"
         result = run_command <<-BASH
           opscode_ruby="/opt/opscode/embedded/bin/ruby"
 


### PR DESCRIPTION
The omnibus installer currently installs 0.10.8 and when you try to run 'knife cook' it reports that the gem version on the remote is out of date.  This tiny change makes 'knife cook' look for Chef gem version 0.10.4 and above.

Hope this one is OK too, I just assumed you'd want greater than or equal to 0.10.4; you may owe me a beer after this MASSIVE change :)
