### PR TITLE
modified regex to sub any sudo command with the password.

### DIFF
--- a/lib/knife-solo/ssh_command.rb
+++ b/lib/knife-solo/ssh_command.rb
@@ -154,7 +154,7 @@ module KnifeSolo
       else
         replacement = ''
       end
-      command.sub(/^\s*sudo/, replacement)
+      command.gsub(/sudo/, replacement)
     end
 
     def process_startup_file(command)


### PR DESCRIPTION
this will fix errors in commmands that do not use sudo at the beginning or have more than one sudo per line.

Refers: https://github.com/matschaffer/knife-solo/pull/50
