### PR TITLE
Added an option for specifying the Omnibus installer version

### DIFF
--- a/lib/chef/knife/prepare.rb
+++ b/lib/chef/knife/prepare.rb
@@ -13,6 +13,10 @@ class Chef
 
       banner "knife prepare [user@]hostname (options)"
 
+      option :omnibus_version,
+        :long => "--omnibus-version VERSION",
+        :description => "The version of Omnibus to install"
+
       def run
         super
         bootstrap.bootstrap!

--- a/lib/knife-solo/bootstraps.rb
+++ b/lib/knife-solo/bootstraps.rb
@@ -57,7 +57,13 @@ module KnifeSolo
 
       def omnibus_install
         run_command(http_client_get_url("http://opscode.com/chef/install.sh"))
-        run_command("sudo bash install.sh")
+
+        # `release_version` within install.sh will be installed if
+        # `omnibus_version` is not provided.
+        install_command = "sudo bash install.sh"
+        install_command << " -v #{prepare.config[:omnibus_version]}" if prepare.config[:omnibus_version]
+
+        run_command(install_command)
       end
 
       def ubuntu_omnibus_install

--- a/test/integration/ubuntu12_04_test.rb
+++ b/test/integration/ubuntu12_04_test.rb
@@ -9,6 +9,12 @@ class Ubuntu12_04Test < IntegrationTest
     "ami-098f5760"
   end
 
+  def prepare_server
+    return if server.tags["knife_solo_prepared"]
+    assert_subcommand "prepare --omnibus-version '0.10.10-1'"
+    runner.tag_as_prepared(server)
+  end
+
   include EmptyCook
   include Apache2Cook
 end

--- a/test/prepare_test.rb
+++ b/test/prepare_test.rb
@@ -30,6 +30,14 @@ class PrepareTest < TestCase
     end
   end
 
+  def test_will_specify_omnibus_version
+    Dir.chdir("/tmp") do
+      FileUtils.mkdir("nodes")
+      run_command = command("somehost", "--omnibus-version", "'0.10.8-3'")
+      assert_match "0.10.8-3", run_command.config[:omnibus_version]
+    end
+  end
+
   def test_run_raises_if_operating_system_is_not_supported
     Dir.chdir("/tmp") do
       FileUtils.mkdir("nodes")


### PR DESCRIPTION
Given that Opscode just updated the default `release_version` within Omnibus, I added an option to `prepare` that allows you to override `release_version` with an older version listed in their [S3 package bucket](http://s3.amazonaws.com/opscode-full-stack/).
