### PR TITLE
Updated Chef dependency version constraint to accommodate new versioning scheme

### DIFF
--- a/knife-solo.gemspec
+++ b/knife-solo.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'mocha'
 
-  s.add_dependency 'chef',    '~> 0.10.0'
+  s.add_dependency 'chef',    '>= 0.10.10'
   s.add_dependency 'net-ssh', '>= 2.1.3', '< 2.3.0'
   s.add_dependency 'librarian', '~> 0.0.20'
 

--- a/lib/chef/knife/cook.rb
+++ b/lib/chef/knife/cook.rb
@@ -14,7 +14,7 @@ class Chef
     # Copyright 2009, Trotter Cashion
     class Cook < Knife
       OMNIBUS_EMBEDDED_PATH   = "/opt/opscode/embedded"
-      CHEF_VERSION_CONSTRAINT = "~>0.10.4"
+      CHEF_VERSION_CONSTRAINT = ">=0.10.4"
 
       include KnifeSolo::SshCommand
       include KnifeSolo::KitchenCommand


### PR DESCRIPTION
Aims to resolve #63.
