### PR TITLE
fix determining patch_dir to rsync the patches

### DIFF
--- a/lib/chef/knife/cook.rb
+++ b/lib/chef/knife/cook.rb
@@ -84,7 +84,10 @@ class Chef
       end
 
       def patch_path
-        Array(Chef::Config.cookbook_path).first + "/chef_solo_patches/libraries"
+        cookbook_path_configured = Array(Chef::Config.cookbook_path).first
+        pwd = Dir.pwd
+        cookbook_dir = cookbook_path_configured.gsub("#{pwd}/", '')
+        adjust_rsync_path(chef_path) + "/#{cookbook_dir}" + "/chef_solo_patches/libraries"
       end
 
       def rsync_exclude


### PR DESCRIPTION
working on a mac or a diff. directory structure and deploying to a linux box.
the sync would happen to
/Users/deepak/Developer/chef_cookbooks/cookbooks/chef_solo_patches/libraries
but it should be
/var/chef/cache/cookbooks/chef_solo_patches/libraries
