### PR TITLE
Install Ruby & Rubygems on Ubuntu

### DIFF
--- a/lib/knife-solo/bootstraps.rb
+++ b/lib/knife-solo/bootstraps.rb
@@ -84,6 +84,12 @@ module KnifeSolo
         # Make sure we have rsync on builds that don't include it by default
         # (observed on linode's ubuntu 10.04 images)
         run_command("sudo apt-get install rsync")
+
+        # Install Ruby
+        debian_gem_install
+
+        # Install Rubygem
+        gem_install        
       end
 
       def gem_install

--- a/lib/knife-solo/bootstraps/linux.rb
+++ b/lib/knife-solo/bootstraps/linux.rb
@@ -55,8 +55,7 @@ module KnifeSolo::Bootstraps
       run_command("sudo apt-get update")
 
       ui.msg "Installing required packages..."
-      @packages = %w(ruby ruby-dev libopenssl-ruby irb
-                     build-essential wget ssl-cert rsync)
+      @packages = %w(ruby ruby-dev libopenssl-ruby irb build-essential wget ssl-cert rsync)
       run_command <<-BASH
         sudo DEBIAN_FRONTEND=noninteractive apt-get --yes install #{package_list}
       BASH


### PR DESCRIPTION
I couldn't get knife prepare to install Ruby or Rubygems at all so I've added `debian_gem_install` and `gem_install` to the `ubuntu_omnibus_install` install command.

I've tested this on a new install of Ubuntu 10.04.4 and it works fine. However one thing I have noticed is it spits out the code it's executing as well. Is this something I've done or what? I'm using Mac Mountain Lion with zsh. I changed it to the default login shell but it does the same for some reason.

http://i.qyk.in/PokTS.png

Hope this helps

Edit: I forgot to add, it only seems to print the code when using in verbose mode `-VV`.
