### PR TITLE
[user@] should be optional in prepare command

### DIFF
--- a/lib/knife-solo/kitchen_command.rb
+++ b/lib/knife-solo/kitchen_command.rb
@@ -29,7 +29,7 @@ module KnifeSolo
     end
 
     def first_cli_arg_is_a_hostname?
-      @name_args.first =~ /\A.+\@.+\z/
+      @name_args.first =~ /\A[.+\@]?.+\z/
     end
 
     def validate_first_cli_arg_is_a_hostname!(error_class)


### PR DESCRIPTION
Even though the format is:

```
knife prepare [user@]hostname (options)
```

...the user is required, even if already accounted for in the config file.

Will submit a PR.
