### PR TITLE
knife kitchen command should be idempotent

### DIFF
--- a/lib/chef/knife/kitchen.rb
+++ b/lib/chef/knife/kitchen.rb
@@ -8,13 +8,34 @@ class Chef
       banner "knife kitchen NAME or initialize current directory with '.'"
 
       def run
-        name = @name_args.first
-        mkdir name if name != '.'
-        %w(nodes roles data_bags site-cookbooks cookbooks).each do |dir|
-          mkdir name + "/#{dir}"
-          touch name + "/#{dir}/.gitkeep"
+        raise banner unless base = @name_args.first
+
+        create_kitchen base
+        create_cupboards base, %w(nodes roles data_bags site-cookbooks cookbooks)
+        create_solo_config base
+      end
+
+      private
+
+      def create_cupboards(base, dirs)
+        dirs.each do |dir|
+          cupboard_dir = File.join(base, dir)
+          unless File.exist?(cupboard_dir)
+            mkdir cupboard_dir
+            touch File.join(cupboard_dir, '.gitkeep')
+          end
         end
-        File.open(name + "/solo.rb", 'w') do |f|
+      end
+
+      def create_kitchen(base)
+        mkdir base unless base == '.'
+      end
+
+      def create_solo_config(base)
+        solo_file = File.join(base, 'solo.rb')
+        return if File.exist? solo_file
+
+        File.open(solo_file, 'w') do |f|
           f << <<-RUBY.gsub(/^ {12}/, '')
             file_cache_path           "/tmp/chef-solo"
             data_bag_path             "/tmp/chef-solo/data_bags"


### PR DESCRIPTION
I made `knife kitchen` check if files exist already before trying (and failing) to create them. This allows it to be re-run in an existing directory without raising errors.

Also, refactored `run` into 3 named methods: `create_kitchen`, `create_cupboards`, `create_solo_config`
