### PR TITLE
Add --node-name option to specify node config filename

### DIFF
--- a/lib/chef/knife/cook.rb
+++ b/lib/chef/knife/cook.rb
@@ -43,7 +43,12 @@ class Chef
         :long => '--syntax-check-only',
         :boolean => true,
         :description => "Only run syntax checks - do not run Chef"
-      
+
+      option :chef_node_name,
+        :short => "-N NAME",
+        :long => "--node-name NAME",
+        :description => "The Chef node name for your new node"
+
       def run
         time('Run') do
           validate_params!

--- a/lib/chef/knife/prepare.rb
+++ b/lib/chef/knife/prepare.rb
@@ -30,6 +30,11 @@ class Chef
         :long => "--omnibus-options \"-r -n\"",
         :description => "Pass options to the install.sh script"
 
+      option :chef_node_name,
+        :short => "-N NAME",
+        :long => "--node-name NAME",
+        :description => "The Chef node name for your new node"
+
       def run
         validate_params!
         super

--- a/lib/knife-solo/ssh_command.rb
+++ b/lib/knife-solo/ssh_command.rb
@@ -36,7 +36,7 @@ module KnifeSolo
     end
 
     def node_config
-      Pathname.new("nodes/#{host}.json")
+      Pathname.new("nodes/#{config[:chef_node_name] || host}.json")
     end
 
     def host_descriptor

--- a/test/cook_test.rb
+++ b/test/cook_test.rb
@@ -15,6 +15,18 @@ class CookTest < TestCase
     assert_equal "nodes/myhost.json", cmd.node_config
   end
 
+  def test_takes_node_config_from_option
+    cmd = command("someuser@somehost.domain.com")
+    cmd.config[:chef_node_name] = "mynode"
+    assert_equal "nodes/mynode.json", cmd.node_config.to_s
+  end
+
+  def test_takes_node_config_as_second_arg_even_with_name_option
+    cmd = command("someuser@somehost.domain.com", "nodes/myhost.json")
+    cmd.config[:chef_node_name] = "mynode"
+    assert_equal "nodes/myhost.json", cmd.node_config
+  end
+
   def test_gets_destination_path_from_chef_config
     Chef::Config.file_cache_path "/tmp/chef-solo"
     assert_equal "/tmp/chef-solo", command.chef_path

--- a/test/prepare_test.rb
+++ b/test/prepare_test.rb
@@ -32,6 +32,19 @@ class PrepareTest < TestCase
     end
   end
 
+  def test_generates_a_node_config_from_name_option
+    Dir.chdir("/tmp") do
+      FileUtils.mkdir("nodes")
+
+      cmd = command(@host)
+      cmd.config[:chef_node_name] = "mynode"
+      cmd.generate_node_config
+
+      assert_equal "nodes/mynode.json", cmd.node_config.to_s
+      assert cmd.node_config.exist?
+    end
+  end
+
   def test_will_specify_omnibus_version
     Dir.chdir("/tmp") do
       FileUtils.mkdir("nodes")


### PR DESCRIPTION
By default the node configuration is written to (by `knife prepare`) and read from (by `knife cook`) "nodes/_hostname_.json". The "_hostname_" part can now be overridden using `--node-name` option.

This is particularly useful when provisioning cloud servers that have dynamic DNS names. The option is also consistent with `knife bootstrap`, `knife ec2 server create`, etc.
