### PR TITLE
Add --run-list and --json-attributes options to generate node config

### DIFF
--- a/lib/chef/knife/prepare.rb
+++ b/lib/chef/knife/prepare.rb
@@ -35,6 +35,20 @@ class Chef
         :long => "--node-name NAME",
         :description => "The Chef node name for your new node"
 
+      option :run_list,
+        :short => "-r RUN_LIST",
+        :long => "--run-list RUN_LIST",
+        :description => "Comma separated list of roles/recipes to add to node config",
+        :proc => lambda { |o| o.split(/[\s,]+/) },
+        :default => []
+
+      option :first_boot_attributes,
+        :short => "-j JSON_ATTRIBS",
+        :long => "--json-attributes",
+        :description => "A JSON string to be added to node config",
+        :proc => lambda { |o| JSON.parse(o) },
+        :default => {}
+
       def run
         validate_params!
         super
@@ -47,11 +61,16 @@ class Chef
       end
 
       def generate_node_config
-        File.open(node_config, 'w') do |f|
-          f.print <<-JSON.gsub(/^\s+/, '')
-            { "run_list": [] }
-          JSON
-        end unless node_config.exist?
+        if node_config.exist?
+          ui.msg "Node config '#{node_config}' already exists"
+        else
+          ui.msg "Generating node config '#{node_config}'..."
+          File.open(node_config, 'w') do |f|
+            attributes = config[:first_boot_attributes] || {}
+            run_list = { :run_list => config[:run_list] || [] }
+            f.print attributes.merge(run_list).to_json
+          end
+        end
       end
 
       def operating_system

--- a/test/prepare_test.rb
+++ b/test/prepare_test.rb
@@ -15,6 +15,7 @@ class PrepareTest < TestCase
       cmd.generate_node_config
 
       assert cmd.node_config.exist?
+      assert_match '{"run_list":[]}', cmd.node_config.read
     end
   end
 
@@ -42,6 +43,45 @@ class PrepareTest < TestCase
 
       assert_equal "nodes/mynode.json", cmd.node_config.to_s
       assert cmd.node_config.exist?
+    end
+  end
+
+  def test_generates_a_node_config_with_specified_run_list
+    Dir.chdir("/tmp") do
+      FileUtils.mkdir("nodes")
+
+      cmd = command(@host)
+      cmd.config[:run_list] = %w{ role[base] recipe[foo] }
+      cmd.generate_node_config
+
+      assert_match '{"run_list":["role[base]","recipe[foo]"]}', cmd.node_config.read
+    end
+  end
+
+  def test_generates_a_node_config_with_specified_attributes
+    Dir.chdir("/tmp") do
+      FileUtils.mkdir("nodes")
+
+      cmd = command(@host)
+      cmd.config[:first_boot_attributes] = {
+        "foo" => { "bar" => [ 1, 2 ], "baz" => "x" }
+      }
+      cmd.generate_node_config
+
+      assert_match '{"foo":{"bar":[1,2],"baz":"x"},"run_list":[]}', cmd.node_config.read
+    end
+  end
+
+  def test_generates_a_node_config_with_specified_run_list_and_attributes
+    Dir.chdir("/tmp") do
+      FileUtils.mkdir("nodes")
+
+      cmd = command(@host)
+      cmd.config[:first_boot_attributes] = { "foo" => "bar" }
+      cmd.config[:run_list] = %w{ recipe[baz] }
+      cmd.generate_node_config
+
+      assert_match '{"foo":"bar","run_list":["recipe[baz]"]}', cmd.node_config.read
     end
   end
 


### PR DESCRIPTION
Sometimes it is more convenient to specify the run list on command line option than create or edit the JSON file. Someone may even want to set other node attributes.

This commit adds `--run-list` and `--json-attributes` options to `knife prepare`. The options and their format is the same than in for example `knife bootstrap`.
