### PR TITLE
add -y to rsync install

### DIFF
--- a/lib/knife-solo/bootstraps.rb
+++ b/lib/knife-solo/bootstraps.rb
@@ -84,7 +84,7 @@ module KnifeSolo
         run_command("sudo apt-get update")
         # Make sure we have rsync on builds that don't include it by default
         # (observed on linode's ubuntu 10.04 images)
-        run_command("sudo apt-get install rsync")
+        run_command("sudo apt-get -y install rsync")
       end
 
       def gem_install


### PR DESCRIPTION
If rsync was already installed on the remote host, you may receive this:
rsync is already the newest version.
0 upgraded, 0 newly installed, 0 to remove and 96 not upgraded.
1 not fully installed or removed.
After this operation, 0 B of additional disk space will be used.
Do you want to continue [Y/n]?

If so, the command will hang, and the cook will never begin.
