### PR TITLE
Add whyrun mode support to `cook` command

### DIFF
--- a/lib/chef/knife/cook.rb
+++ b/lib/chef/knife/cook.rb
@@ -37,6 +37,12 @@ class Chef
         :boolean => false,
         :description => "Only sync the cookbook - do not run Chef"
 
+      option :why_run,
+        :short        => '-W',
+        :long         => '--why-run',
+        :boolean      => true,
+        :description  => "Enable whyrun mode"
+
       def run
         time('Run') do
           validate_params!
@@ -115,6 +121,7 @@ class Chef
         cmd = "sudo chef-solo -c #{chef_path}/solo.rb -j #{chef_path}/#{node_config}"
         cmd << " -l debug" if debug?
         cmd << " -N #{config[:chef_node_name]}" if config[:chef_node_name]
+        cmd << " -W" if config[:why_run]
 
         stream_command cmd
       end

--- a/test/cook_test.rb
+++ b/test/cook_test.rb
@@ -44,6 +44,10 @@ class CookTest < TestCase
     assert_chef_solo_option "--node-name=mynode", "-N mynode"
   end
 
+  def test_passes_whyrun_mode_to_chef_solo
+    assert_chef_solo_option "--why-run", "-W"
+  end
+
   # Asserts that the chef_solo_option is passed to chef-solo iff cook_option
   # is specified for the cook command
   def assert_chef_solo_option(cook_option, chef_solo_option)


### PR DESCRIPTION
Pass `--why-run` option to chef-solo if specified.
