### PR TITLE
Use SSL when downloading Omnibus packages

### DIFF
--- a/lib/knife-solo/bootstraps.rb
+++ b/lib/knife-solo/bootstraps.rb
@@ -66,7 +66,7 @@ module KnifeSolo
       end
 
       def omnibus_install
-        url = prepare.config[:omnibus_url] || "http://opscode.com/chef/install.sh"
+        url = prepare.config[:omnibus_url] || "https://www.opscode.com/chef/install.sh"
         file = File.basename(url)
         http_client_get_url(url, file)
         # `release_version` within install.sh will be installed if


### PR DESCRIPTION
Using SSL to fetch the install.sh will help to  ensure you receive a copy that has not been modified by a MITM attack.
