### PR TITLE
Scientific Linux 6 minimal does not include rsync

### DIFF
--- a/lib/knife-solo/bootstraps.rb
+++ b/lib/knife-solo/bootstraps.rb
@@ -78,6 +78,13 @@ module KnifeSolo
         stream_command(install_command)
       end
 
+      def yum_omnibus_install
+        omnibus_install
+        # Make sure we have rsync on builds that don't include it by default
+        # (for example Scientific Linux minimal)
+        run_command("sudo yum -y install rsync")
+      end
+
       def debianoid_omnibus_install
         omnibus_install
         # Update to avoid out-of-date package caches

--- a/lib/knife-solo/bootstraps/linux.rb
+++ b/lib/knife-solo/bootstraps/linux.rb
@@ -94,7 +94,7 @@ module KnifeSolo::Bootstraps
       when %r{Scientific Linux.*? 5}
         {:type => "omnibus", :version => "RHEL5"}
       when %r{Scientific Linux.*? 6}
-        {:type => "omnibus", :version => "RHEL6"}
+        {:type => "yum_omnibus", :version => "RHEL6"}
       when %r{SUSE Linux Enterprise Server 11 SP1}
         {:type => "zypper_gem", :version => "SLES11"}
       when %r{openSUSE 11.4}


### PR DESCRIPTION
This vagrant box for example http://lyte.id.au/vagrant/sl6-64-lyte.box from http://www.vagrantbox.es/
