### PR TITLE
sudo the chef version check

### DIFF
--- a/lib/chef/knife/cook.rb
+++ b/lib/chef/knife/cook.rb
@@ -111,8 +111,9 @@ class Chef
       def check_chef_version
         ui.msg "Checking Chef version..."
         result = run_command <<-BASH
-          export PATH="#{OMNIBUS_EMBEDDED_PATHS.join(":")}:$PATH"
-          ruby -rubygems -e "gem 'chef', '#{CHEF_VERSION_CONSTRAINT}'"
+          sudo bash -c \\
+            "export PATH=\\"#{OMNIBUS_EMBEDDED_PATHS.join(":")}:\\$PATH\\" && \\
+            ruby -rubygems -e \\"gem 'chef', '#{CHEF_VERSION_CONSTRAINT}'\\""
         BASH
         raise "Couldn't find Chef #{CHEF_VERSION_CONSTRAINT} on #{host}. Please run `#{$0} prepare #{ssh_args}` to ensure Chef is installed and up to date." unless result.success?
       end


### PR DESCRIPTION
if system wide rvm is installed and there is a default ruby then this would
fail. This ensures that the ruby used is the omnibus ruby.

There may be a better way to pass the environment than I'm doing it here, I'm
not sure.
