### PR TITLE
Do not print a message if the node config exists

### DIFF
--- a/lib/knife-solo/node_config_command.rb
+++ b/lib/knife-solo/node_config_command.rb
@@ -25,7 +25,7 @@ module KnifeSolo
 
     def generate_node_config
       if node_config.exist?
-        ui.msg "Node config '#{node_config}' already exists"
+        Chef::Log.debug "Node config '#{node_config}' already exists"
       else
         ui.msg "Generating node config '#{node_config}'..."
         File.open(node_config, 'w') do |f|


### PR DESCRIPTION
The message itself isn't terribly helpful and it led me to think I was doing
something wrong.
