### PR TITLE
Fix bundler invalid gemspec warning

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -5,7 +5,7 @@ Rakefile
 lib/chef/knife/cook.rb
 lib/chef/knife/kitchen.rb
 lib/chef/knife/patches/parser.rb
-lib/chef/knife/patches/search_patch.rb
+lib/chef/knife/patches/search.rb
 lib/chef/knife/prepare.rb
 lib/chef/knife/solo_bootstrap.rb
 lib/chef/knife/solo_clean.rb


### PR DESCRIPTION
Just a change to the Manifest.txt, to rename search_patch.rb to search.rb. Ensuring bundler doesn't warn any more
