### PR TITLE
Always install rsync from yum on RPM-based Linuxes

### DIFF
--- a/lib/knife-solo/bootstraps.rb
+++ b/lib/knife-solo/bootstraps.rb
@@ -81,7 +81,7 @@ module KnifeSolo
       def yum_omnibus_install
         omnibus_install
         # Make sure we have rsync on builds that don't include it by default
-        # (for example Scientific Linux minimal)
+        # (for example Scientific Linux minimal, CentOS minimal)
         run_command("sudo yum -y install rsync")
       end
 

--- a/lib/knife-solo/bootstraps/linux.rb
+++ b/lib/knife-solo/bootstraps/linux.rb
@@ -85,21 +85,21 @@ module KnifeSolo::Bootstraps
         version = run_command("lsb_release -cs").stdout.strip
         {:type => "debian_gem", :version => version}
       when %r{CentOS.*? 5}
-        {:type => "omnibus", :version => "RHEL5"}
+        {:type => "yum_omnibus", :version => "RHEL5"}
       when %r{CentOS.*? 6}
-        {:type => "omnibus", :version => "RHEL6"}
+        {:type => "yum_omnibus", :version => "RHEL6"}
       when %r{Red Hat Enterprise.*? 5}
-        {:type => "omnibus", :version => "RHEL5"}
+        {:type => "yum_omnibus", :version => "RHEL5"}
       when %r{Red Hat Enterprise.*? 6}
-        {:type => "omnibus", :version => "RHEL6"}
+        {:type => "yum_omnibus", :version => "RHEL6"}
       when %r{Fedora release.*? 15}
-        {:type => "omnibus", :version => "FC15"}
+        {:type => "yum_omnibus", :version => "FC15"}
       when %r{Fedora release.*? 16}
-        {:type => "omnibus", :version => "FC16"}
+        {:type => "yum_omnibus", :version => "FC16"}
       when %r{Fedora release.*? 17}
-        {:type => "omnibus", :version => "FC17"}
+        {:type => "yum_omnibus", :version => "FC17"}
       when %r{Scientific Linux.*? 5}
-        {:type => "omnibus", :version => "RHEL5"}
+        {:type => "yum_omnibus", :version => "RHEL5"}
       when %r{Scientific Linux.*? 6}
         {:type => "yum_omnibus", :version => "RHEL6"}
       when %r{SUSE Linux Enterprise Server 1[12]}


### PR DESCRIPTION
This commit runs `sudo yum install -y rsync` after the Chef Omnibus install on RPM-based Linuxes.

The core use case is for CentOS minimal, which does not include rsync.

See this issue: [Scientific Linux 6 minimal does not include rsync](https://github.com/matschaffer/knife-solo/pull/131) (https://github.com/matschaffer/knife-solo/pull/131)
