### PR TITLE
Fix `--omnibus-options` passing to Omnibus Installer

### DIFF
--- a/lib/knife-solo/bootstraps.rb
+++ b/lib/knife-solo/bootstraps.rb
@@ -73,7 +73,7 @@ module KnifeSolo
         # `omnibus_version` is not provided.
         install_command = "sudo bash #{file}"
         install_command << " -v #{prepare.config[:omnibus_version]}" if prepare.config[:omnibus_version]
-        install_command << " #{prepare.config[:options]}" if prepare.config[:options]
+        install_command << " #{prepare.config[:omnibus_options]}" if prepare.config[:omnibus_options]
 
         stream_command(install_command)
       end


### PR DESCRIPTION
It seems that all the refactoring in PR #99 skipped renaming the option
in `KnifeSolo::Bootstraps`.

There are no tests for the Omnibus options and they are a bit tricky to
implement, so they are left as an exercise for the reader. Maybe
something like #assert_chef_solo_option in the Cook tests?
