### PR TITLE
Rename ':first_boot_attributes' option

### DIFF
--- a/lib/knife-solo/node_config_command.rb
+++ b/lib/knife-solo/node_config_command.rb
@@ -23,7 +23,7 @@ module KnifeSolo
           :proc        => lambda { |o| o.split(/[\s,]+/) },
           :default     => []
 
-        option :first_boot_attributes,
+        option :json_attributes,
           :short       => '-j JSON_ATTRIBS',
           :long        => '--json-attributes',
           :description => 'A JSON string to be added to node config (if it does not exist)',
@@ -43,7 +43,7 @@ module KnifeSolo
       else
         ui.msg "Generating node config '#{node_config}'..."
         File.open(node_config, 'w') do |f|
-          attributes = config[:first_boot_attributes] || {}
+          attributes = config[:json_attributes] || {}
           run_list = { :run_list => config[:run_list] || [] }
           f.print attributes.merge(run_list).to_json
         end


### PR DESCRIPTION
I'm using knife-solo along with knife-ec2 using the POC from @tmatilai.  When running `knife ec2 server create --solo --json-attributes X` the attributes passed in were not getting assigned to the `:first_boot_attributes` option but rather the `:json_attributes` option defined in knife-ec2.

I changed the option name to match the option from knife-ec2.  This works regardless of whether you integrate with knife-ec2 or not.

The other options defined here (`:run_list`, `:chef_node_name`) already match those in knife-ec2 so there is no conflict when using those.
