### PR TITLE
Fix duplicate constant definitions for Ruby 1.8

### DIFF
--- a/lib/chef/knife/solo_cook.rb
+++ b/lib/chef/knife/solo_cook.rb
@@ -10,9 +10,9 @@ class Chef
     # Approach ported from spatula (https://github.com/trotter/spatula)
     # Copyright 2009, Trotter Cashion
     class SoloCook < Knife
-      OMNIBUS_EMBEDDED_PATHS     ||= %w[/opt/chef/embedded/bin /opt/opscode/embedded/bin]
-      OMNIBUS_EMBEDDED_GEM_PATHS ||= %w[/opt/chef/embedded/lib/ruby/gems/1.9.1 /opt/opscode/embedded/lib/ruby/gems/1.9.1]
-      CHEF_VERSION_CONSTRAINT    ||= ">=0.10.4"
+      OMNIBUS_EMBEDDED_PATHS     = %w[/opt/chef/embedded/bin /opt/opscode/embedded/bin] unless defined? OMNIBUS_EMBEDDED_PATHS
+      OMNIBUS_EMBEDDED_GEM_PATHS = %w[/opt/chef/embedded/lib/ruby/gems/1.9.1 /opt/opscode/embedded/lib/ruby/gems/1.9.1] unless defined? OMNIBUS_EMBEDDED_PATHS
+      CHEF_VERSION_CONSTRAINT    = ">=0.10.4" unless defined? OMNIBUS_EMBEDDED_PATHS
 
       include KnifeSolo::SshCommand
       include KnifeSolo::KitchenCommand


### PR DESCRIPTION
Ruby 1.8.7 does not like the `||=` construction for Class constants,
so use `defined?` to check if the constants are already declared.

Fixes #169.
