### PR TITLE
Pepare fails on Debian 7.0 wheezy

### DIFF
--- a/lib/knife-solo/bootstraps/linux.rb
+++ b/lib/knife-solo/bootstraps/linux.rb
@@ -77,11 +77,11 @@ module KnifeSolo::Bootstraps
       return @distro if @distro
       @distro = case issue
       when %r{Debian GNU/Linux 6}
-        {:type => if x86? then "debianoid_omnibus" else "debian_gem" end, :version => "squeeze"}
+        {:type => (x86? ? "debianoid_omnibus" : "debian_gem"), :version => "squeeze"}
       when %r{Debian}
         {:type => "debian_gem", :version => lsb_release_codename}
       when %r{Ubuntu}i
-        {:type => if x86? then "debianoid_omnibus" else "debian_gem" end, :version => lsb_release_codename}
+        {:type => (x86? ? "debianoid_omnibus" : "debian_gem"), :version => lsb_release_codename}
       when %r{Linaro}
         {:type => "debian_gem", :version => lsb_release_codename}
       when %r{CentOS.*? 5}


### PR DESCRIPTION
Omnibus is not supported until Wheezy is released (see #165).
