### PR TITLE
Issues running both ubuntu12 integration tests at the same time

### DIFF
--- a/test/support/integration_test.rb
+++ b/test/support/integration_test.rb
@@ -15,7 +15,7 @@ class IntegrationTest < TestCase
   # Returns a name for the current test's server
   # that should be fairly unique.
   def server_name
-    "knife_solo-#{image_id}"
+    "knife-solo_#{self.class}"
   end
 
   # Shortcut to access the test runner


### PR DESCRIPTION
When running all integration tests I seem to get this error consistently

```
# Running tests:

...........rsync: change_dir#3 "/tmp/chef-solo/site-cookbooks/chef_solo_patches" failed: No such file or directory (2)
rsync error: errors selecting input/output files, dirs (code 3) at main.c(643) [Receiver=3.0.9]
rsync: connection unexpectedly closed (8 bytes received so far) [sender]
rsync error: error in rsync protocol data stream (code 12) at /SourceCache/rsync/rsync-42/rsync/io.c(452) [sender=2.6.9]
ERROR: RuntimeError: Failed to launch command rsync -rl --rsh="ssh ubuntu@23.20.116.253 -i /Users/mat/code/knife-solo/test/support/knife-solo.pem" /Users/mat/code/knife-solo/lib/chef/knife/patches/parser.rb :/tmp/chef-solo/site-cookbooks/chef_solo_patches/libraries
F....

Finished tests in 424.541211s, 0.0377 tests/s, 0.0801 assertions/s.

  1) Failure:
test_apache2(Ubuntu12_04BootstrapTest) [/Users/mat/code/knife-solo/test/integration/cases/apache2_bootstrap.rb:11]:
Failed assertion, no message given.

16 tests, 34 assertions, 1 failures, 0 errors, 0 skips
rake aborted!
Command failed with status (1): [ruby -I"lib:test" -I"/Users/mat/.rvm/gems/ruby-1.9.3-p327/gems/rake-10.0.3/lib" "/Users/mat/.rvm/gems/ruby-1.9.3-p327/gems/rake-10.0.3/lib/rake/rake_test_loader.rb" "test/integration/centos5_6_test.rb" "test/integration/gentoo2011_test.rb" "test/integration/omnios_r151004_test.rb" "test/integration/scientific_linux_63_test.rb" "test/integration/sles_11_test.rb" "test/integration/ubuntu10_04_test.rb" "test/integration/ubuntu12_04_bootstrap_test.rb" "test/integration/ubuntu12_04_test.rb" ]

Tasks: TOP => test:all => test:integration
(See full trace by running task with --trace)
```

But running the test by itself after that works fine.
