### PR TITLE
Support `--ssh-user` option

### DIFF
--- a/lib/knife-solo/ssh_command.rb
+++ b/lib/knife-solo/ssh_command.rb
@@ -26,6 +26,11 @@ module KnifeSolo
           :long        => '--ssh-config-file CONFIG_FILE',
           :description => 'Alternate location for ssh config file'
 
+        option :ssh_user,
+          :short       => '-x USERNAME',
+          :long        => '--ssh-user USERNAME',
+          :description => 'The ssh username'
+
         option :ssh_password,
           :short       => '-P PASSWORD',
           :long        => '--ssh-password PASSWORD',
@@ -65,6 +70,9 @@ module KnifeSolo
         show_usage
         ui.fatal "You must specify [<user>@]<hostname> as the first argument"
         exit 1
+      end
+      if config[:ssh_user]
+        host_descriptor[:user] ||= config[:ssh_user]
       end
     end
 

--- a/test/ssh_command_test.rb
+++ b/test/ssh_command_test.rb
@@ -19,6 +19,18 @@ class SshCommandTest < TestCase
     assert_equal "test", command("10.0.0.1").user
   end
 
+  def test_takes_user_from_options
+    cmd = command("10.0.0.1", "--ssh-user=test")
+    cmd.validate_ssh_options!
+    assert_equal "test", cmd.user
+  end
+
+  def test_takes_user_as_arg
+    cmd = command("test@10.0.0.1", "--ssh-user=ignored")
+    cmd.validate_ssh_options!
+    assert_equal "test", cmd.user
+  end
+
   def test_host_regex_rejects_invalid_hostnames
     %w[@name @@name.com name@ name@@ joe@@example.com joe@name@example.com].each do |invalid|
       cmd = command(invalid)


### PR DESCRIPTION
Support "--ssh-user" option to specify the username. This is compatible with `knife bootstrap` etc.

The "user@hostname" way should also be kept as an alternative and for backwards compatibility.

(In the future it would also be fancy to be able to specify it in knife.rb instead of always typing it on the command line. But this has to wait for solo.rb/knife.rb changes.)
