### PR TITLE
add option to skip librarian install

### DIFF
--- a/lib/chef/knife/solo_cook.rb
+++ b/lib/chef/knife/solo_cook.rb
@@ -62,7 +62,7 @@ class Chef
           Chef::Config.from_file('solo.rb')
           check_chef_version if config[:chef_check]
           generate_node_config
-          librarian_install unless config[:skip_librarian]
+          librarian_install if config[:librarian]
           rsync_kitchen
           add_patches
           cook unless config[:sync_only]

--- a/test/solo_cook_test.rb
+++ b/test/solo_cook_test.rb
@@ -62,6 +62,19 @@ class SoloCookTest < TestCase
     assert_chef_solo_option "--why-run", "-W"
   end
 
+  def test_no_librarian_option
+    solo_cook = command("somehost", "--no-librarian")
+    solo_cook.expects(:librarian_install).never
+    solo_cook.stubs(:validate!)
+    Chef::Config.stubs(:from_file)
+    solo_cook.stubs(:check_chef_version)
+    solo_cook.stubs(:generate_node_config)
+    solo_cook.stubs(:rsync_kitchen)
+    solo_cook.stubs(:add_patches)
+    solo_cook.stubs(:cook)
+    solo_cook.run
+  end
+
   # Asserts that the chef_solo_option is passed to chef-solo iff cook_option
   # is specified for the cook command
   def assert_chef_solo_option(cook_option, chef_solo_option)


### PR DESCRIPTION
Provide option to skip librarian install when running cook.

I'm working on https://github.com/substantial/sous-chef a gem that manages the knife-solo nodes. I'm currently using rake and I wanted to support running cook on multiple nodes in parallel (using rake multitask). I ran into a race condition where rsync on one thread was upset when another thread was running librarian install.
