### PR TITLE
Recommend removing old gems on installation

### DIFF
--- a/knife-solo.gemspec
+++ b/knife-solo.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |s|
   s.test_files    = manifest.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]
 
+   s.post_install_message = KnifeSolo.post_install_message
+
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'mocha'

--- a/lib/knife-solo/info.rb
+++ b/lib/knife-solo/info.rb
@@ -3,6 +3,21 @@ module KnifeSolo
     '0.2.0.pre2'
   end
 
+  def self.post_install_message
+    <<-TXT.gsub(/^ {6}/, '').strip
+      Thanks for installing knife-solo!
+
+      If you run into any issues please let us know at:
+        https://github.com/matschaffer/knife-solo/issues
+
+      If you are upgrading knife-solo please uninstall any old versions by
+      running `gem clean knife-solo` to avoid any errors.
+
+      See http://bit.ly/CHEF-3255 for more information on the knife bug
+      that causes this.
+    TXT
+  end
+
   def self.prerelease?
     Gem::Version.new(self.version).prerelease?
   end


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-3255 shows that loading old gem code is still an issue. We should include a post-install message to warn people about this. 
