### PR TITLE
Clear the yum cached data before rsync install.

### DIFF
--- a/lib/knife-solo/bootstraps.rb
+++ b/lib/knife-solo/bootstraps.rb
@@ -76,6 +76,8 @@ module KnifeSolo
 
       def yum_omnibus_install
         omnibus_install
+        # Avoid rsync not being found in package cache.
+        run_command("sudo yum clean all")
         # Make sure we have rsync on builds that don't include it by default
         # (for example Scientific Linux minimal, CentOS minimal)
         run_command("sudo yum -y install rsync")


### PR DESCRIPTION
Sometimes rsync does not install because yum fails to locate it in the
various places it knows about.  This commit protects against this issue
by forcing yum to locate new package repositories prior to installing
rysnc.
