### PR TITLE
Fix windows client rsync.

### DIFF
--- a/lib/chef/knife/solo_cook.rb
+++ b/lib/chef/knife/solo_cook.rb
@@ -85,9 +85,29 @@ class Chef
         @chefignore ||= ::Chef::Cookbook::Chefignore.new("./")
       end
 
+      # cygwin rsync path must be adjusted to work
+      def adjust_rsync_path(path)
+        path_s = path.to_s
+        path_s.gsub(/^(\w):/) { "/cygdrive/#{$1}" }
+      end
+
+      def adjust_rsync_path_on_node(path)
+        return path unless windows_node?
+        adjust_rsync_path(path)
+      end
+
+      def adjust_rsync_path_on_client(path)
+        return path unless windows_client?
+        adjust_rsync_path(path)
+      end
+
       # see http://stackoverflow.com/questions/5798807/rsync-permission-denied-created-directories-have-no-permissions
       def rsync_permissions
         '--chmod=ugo=rwX' if windows_client?
+      end
+
+      def patch_path
+        Array(Chef::Config.cookbook_path).first + "/chef_solo_patches/libraries"
       end
 
       def rsync_excludes
@@ -138,7 +158,7 @@ class Chef
       end
 
       def rsync(source_path, target_path, extra_opts = '')
-        cmd = %Q|rsync -rl #{rsync_permissions} --rsh="ssh #{ssh_args}" #{extra_opts} #{rsync_excludes.collect{ |ignore| "--exclude #{ignore} " }.join} #{source_path} :#{target_path}|
+        cmd = %Q{rsync -rl #{rsync_permissions} --rsh="ssh #{ssh_args}" #{extra_opts} #{rsync_excludes.collect{ |ignore| "--exclude #{ignore} " }.join} #{adjust_rsync_path_on_client(source_path)} :#{adjust_rsync_path_on_node(target_path)}}
         ui.msg cmd if debug?
         system! cmd
       end


### PR DESCRIPTION
After upgrading to `knife-solo (0.3.0.pre2)` the `cook` command stopped
working on my windows7 build.

Comparing against the commits in matschaffer/knife-solo#156, I noticed that some pertinent code was lost in the last refactoring process.

I cherry-picked commit 19197ca132d138bfc212cae2e37c37717eff0464

And added one minor change because `path.gsub` was failing since path
was not being passed as a string to `adjust_rsync_path`

Conflicts:
    lib/chef/knife/solo_cook.rb
    lib/knife-solo/tools.rb
