### PR TITLE
support --override-runlist option

### DIFF
--- a/lib/chef/knife/solo_cook.rb
+++ b/lib/chef/knife/solo_cook.rb
@@ -51,6 +51,11 @@ class Chef
         :long        => '--why-run',
         :description => 'Enable whyrun mode'
 
+      option :override_runlist,
+        :short       => '-o RunlistItem,RunlistItem...,',
+        :long        => '--override-runlist',
+        :description => 'Replace current run list with specified items'
+
       def run
         @solo_config = KnifeSolo::Config.new
 
@@ -177,6 +182,7 @@ class Chef
         cmd << " -l debug" if debug?
         cmd << " -N #{config[:chef_node_name]}" if config[:chef_node_name]
         cmd << " -W" if config[:why_run]
+        cmd << " -o #{config[:override_runlist]}" if config[:override_runlist]
 
         result = stream_command cmd
         raise "chef-solo failed. See output above." unless result.success?

--- a/test/solo_cook_test.rb
+++ b/test/solo_cook_test.rb
@@ -122,6 +122,10 @@ class SoloCookTest < TestCase
     assert_chef_solo_option "--why-run", "-W"
   end
 
+  def test_passes_override_runlist_to_chef_solo
+    assert_chef_solo_option "--override-runlist=sandbox::default", "-o sandbox::default"
+  end
+
   # Asserts that the chef_solo_option is passed to chef-solo iff cook_option
   # is specified for the cook command
   def assert_chef_solo_option(cook_option, chef_solo_option)


### PR DESCRIPTION
Add chef-solo's "--override-runlist (-o)" option to "knife solo cook" command.
This is a proposal.
