### PR TITLE
Default to installing the same Chef version on the node as is used on work station

### DIFF
--- a/lib/chef/knife/solo_prepare.rb
+++ b/lib/chef/knife/solo_prepare.rb
@@ -60,8 +60,11 @@ class Chef
       end
 
       def chef_version
-        v = Chef::Config[:knife][:bootstrap_version]
-        (v && !v.empty?) ? v : nil
+        if (v = Chef::Config[:knife][:bootstrap_version])
+          v.empty? ? nil : v
+        else
+          Chef::VERSION
+        end
       end
     end
   end

--- a/test/integration/cases/apache2_bootstrap.rb
+++ b/test/integration/cases/apache2_bootstrap.rb
@@ -8,7 +8,7 @@ module Apache2Bootstrap
 
   def test_apache2
     write_cheffile
-    assert_subcommand "bootstrap --run-list=recipe[apache2] #{omnibus_options}"
+    assert_subcommand "bootstrap --run-list=recipe[apache2]"
     assert_match default_apache_message, http_response
   end
 end

--- a/test/solo_prepare_test.rb
+++ b/test/solo_prepare_test.rb
@@ -12,12 +12,23 @@ class SoloPrepareTest < TestCase
     @host = 'someuser@somehost.domain.com'
   end
 
+  def test_uses_local_chef_version_by_default
+    Chef::Config[:knife][:bootstrap_version] = nil
+    assert_equal Chef::VERSION, command.chef_version
+  end
+
   def test_uses_chef_version_from_knife_config
     Chef::Config[:knife][:bootstrap_version] = "10.12.2"
-    assert_match "10.12.2", command.chef_version
+    assert_equal "10.12.2", command.chef_version
+  end
+
+  def test_uses_chef_version_from_command_line_option
+    Chef::Config[:knife][:bootstrap_version] = "10.16.2"
+    assert_equal "0.4.2", command("--bootstrap-version", "0.4.2").chef_version
   end
 
   def test_chef_version_returns_nil_if_empty
+    Chef::Config[:knife][:bootstrap_version] = "10.12.2"
     assert_nil command("--bootstrap-version", "").chef_version
   end
 

--- a/test/support/integration_test.rb
+++ b/test/support/integration_test.rb
@@ -72,14 +72,7 @@ class IntegrationTest < TestCase
 
   # The prepare command to use on this server
   def prepare_command
-    "prepare #{omnibus_options}"
-  end
-
-  def omnibus_options
-    return "" if ENV['CHEF_VERSION'].to_s.empty?
-
-    v = `knife --version`.split(':')
-    v[0].strip == 'Chef' ? "--bootstrap-version=#{v[1].strip}" : ''
+    "prepare"
   end
 
   # Provides the path to the runner's key file


### PR DESCRIPTION
`knife bootstrap` works like this, and it offers less surprises like currently when Chef 11 is released. This is related to #185 as the same logic would be good for both omnibus and gem installers.

<!---
@huboard:{"order":164.0}
-->
