### PR TITLE
Add `--prerelease` option to prepare command

### DIFF
--- a/lib/chef/knife/solo_prepare.rb
+++ b/lib/chef/knife/solo_prepare.rb
@@ -23,6 +23,10 @@ class Chef
         :description => 'The version of Chef to install',
         :proc        => lambda {|v| Chef::Config[:knife][:bootstrap_version] = v}
 
+      option :prerelease,
+        :long        => '--prerelease',
+        :description => 'Install the pre-release Chef version'
+
       option :omnibus_url,
         :long        => '--omnibus-url URL',
         :description => 'URL to download install.sh from'

--- a/lib/knife-solo/bootstraps.rb
+++ b/lib/knife-solo/bootstraps.rb
@@ -81,7 +81,11 @@ module KnifeSolo
 
       def omnibus_options
         options = prepare.config[:omnibus_options] || ""
-        options << " -v #{chef_version}" if chef_version
+        if prepare.config[:prerelease]
+          options << " -p"
+        elsif chef_version
+          options << " -v #{chef_version}"
+        end
         options
       end
 
@@ -117,7 +121,11 @@ module KnifeSolo
       end
 
       def gem_options
-        "--version #{chef_version}" if chef_version
+        if prepare.config[:prerelease]
+          "--prerelease"
+        elsif chef_version
+          "--version #{chef_version}"
+        end
       end
     end #InstallCommands
 

--- a/test/bootstraps_test.rb
+++ b/test/bootstraps_test.rb
@@ -81,10 +81,24 @@ class BootstrapsTest < TestCase
     assert_equal "-s -v 0.10.8-3", bootstrap.omnibus_options
   end
 
+  def test_passes_prerelease_omnibus_version
+    bootstrap = bootstrap_instance
+    bootstrap.prepare.stubs(:chef_version).returns("10.18.3")
+    bootstrap.prepare.stubs(:config).returns({:prerelease => true})
+    assert_equal "-p", bootstrap.omnibus_options.strip
+  end
+
   def test_passes_gem_version
     bootstrap = bootstrap_instance
     bootstrap.prepare.stubs(:chef_version).returns("10.16.4")
     assert_equal "--version 10.16.4", bootstrap.gem_options
+  end
+
+  def test_passes_prereleaes_gem_version
+    bootstrap = bootstrap_instance
+    bootstrap.prepare.stubs(:chef_version).returns("10.18.1")
+    bootstrap.prepare.stubs(:config).returns({:prerelease => true})
+    assert_equal "--prerelease", bootstrap.gem_options
   end
 
   def test_wont_pass_unset_gem_version
@@ -97,6 +111,7 @@ class BootstrapsTest < TestCase
 
   def bootstrap_instance
     prepare = mock('Knife::Chef::SoloPrepare')
+    prepare.stubs(:config).returns({})
     KnifeSolo::Bootstraps::StubOS.new(prepare)
   end
 end


### PR DESCRIPTION
In continuation to #185 we could add `--prerelease` option to install a pre-release version of Chef to the node.

<!---
@huboard:{"order":164.0}
-->
