### PR TITLE
Support OS X 10.6-10.8 via Omnibus installer

### DIFF
--- a/lib/knife-solo/bootstraps/darwin.rb
+++ b/lib/knife-solo/bootstraps/darwin.rb
@@ -2,28 +2,16 @@ module KnifeSolo::Bootstraps
   class Darwin < Base
 
     def issue
-      run_command("sw_vers -productVersion").stdout.strip
+      @issue ||= run_command("sw_vers -productVersion").stdout.strip
     end
 
     def distro
       case issue
-      when %r{10.5}
-          {:type => 'gem', :version => 'leopard'}
-      when %r{10.6}
-          {:type => 'gem', :version => 'snow_leopard'}
+      when %r{10.[6-8]}
+        {:type => 'omnibus'}
       else
-          raise "OSX version #{issue} not supported"
+        raise "OS X version #{issue} not supported"
       end
     end
-
-    def has_xcode_installed?
-      result = run_command("xcodebuild -version")
-      result.success?
-    end
-
-    def run_pre_bootstrap_checks
-      raise 'xcode not installed, which is required to do anything.  please install and run again.' unless has_xcode_installed?
-    end
-
   end
 end

--- a/test/bootstraps_test.rb
+++ b/test/bootstraps_test.rb
@@ -43,16 +43,6 @@ class BootstrapsTest < TestCase
     assert_equal prepare, bootstrap.prepare
   end
 
-  def test_darwin_checks_for_xcode_install_and_barfs_if_missing
-    bootstrap = KnifeSolo::Bootstraps::Darwin.new(mock)
-    bootstrap.stubs(:gem_install)
-    bootstrap.expects(:has_xcode_installed?).returns(false)
-
-    assert_raises RuntimeError do
-      bootstrap.bootstrap!
-    end
-  end
-
   def test_omnibus_install_methdod
     bootstrap = bootstrap_instance
     bootstrap.stubs(:distro).returns({:type => "omnibus"})


### PR DESCRIPTION
No need for Xcode as the Omnibus package includes everything.
Also drop support for OS X 10.5.

Fixes #209.
