### PR TITLE
Add Fedora 18

### DIFF
--- a/lib/knife-solo/bootstraps/linux.rb
+++ b/lib/knife-solo/bootstraps/linux.rb
@@ -82,6 +82,8 @@ module KnifeSolo::Bootstraps
         {:type => "yum_omnibus"}
       when %r{Fedora release.*? 17}
         {:type => "yum_omnibus"}
+      when %r{Fedora release.*? 18}
+        {:type => "yum_omnibus"}
       when %r{Scientific Linux.*? 5}
         {:type => "yum_omnibus"}
       when %r{Scientific Linux.*? 6}


### PR DESCRIPTION
I have added Fedroa 18 to known platforms. It works with older bootstrap method. 
