### PR TITLE
fix error

### DIFF
--- a/lib/knife-solo.rb
+++ b/lib/knife-solo.rb
@@ -1,4 +1,5 @@
 require 'knife-solo/info'
+require 'pathname'
 
 module KnifeSolo
   def self.resource(name)


### PR DESCRIPTION
$ knife solo init chef-repo -VV
Creating kitchen...
Creating knife.rb in kitchen...
/usr/lib/ruby/gems/1.8/gems/knife-solo-0.3.0.pre4/lib/knife-solo.rb:5:in `resource': uninitialized constant KnifeSolo::Pathname (NameError)
        from /usr/lib/ruby/gems/1.8/gems/knife-solo-0.3.0.pre4/lib/chef/knife/solo_init.rb:62:in`create_config'
        from /usr/lib/ruby/gems/1.8/gems/knife-solo-0.3.0.pre4/lib/chef/knife/solo_init.rb:28:in `run'
        from /usr/lib/ruby/gems/1.8/gems/chef-11.4.0/lib/chef/knife.rb:460:in`run_with_pretty_exceptions'
        from /usr/lib/ruby/gems/1.8/gems/chef-11.4.0/lib/chef/knife.rb:173:in `run'
        from /usr/lib/ruby/gems/1.8/gems/chef-11.4.0/lib/chef/application/knife.rb:123:in`run'
        from /usr/lib/ruby/gems/1.8/gems/chef-11.4.0/bin/knife:25
        from /usr/bin/knife:19:in `load'
        from /usr/bin/knife:19
