### PR TITLE
Fix deprecated commands

### DIFF
--- a/lib/knife-solo/deprecated_command.rb
+++ b/lib/knife-solo/deprecated_command.rb
@@ -9,6 +9,10 @@ module KnifeSolo
 
         banner deprecated
         self.options = superclass.options
+
+        def self.load_deps
+          superclass.load_deps
+        end
       end
     end
 

--- a/test/deprecated_command_test.rb
+++ b/test/deprecated_command_test.rb
@@ -47,6 +47,11 @@ class DeprecatedCommandTest < TestCase
     assert DummyDeprecatedCommand.options.include?(:foo)
   end
 
+  def test_loads_dependencies_from_new_command
+    DummyNewCommand.expects(:load_deps)
+    DummyDeprecatedCommand.load_deps
+  end
+
   def command(*args)
     DummyDeprecatedCommand.load_deps
     DummyDeprecatedCommand.new(args)


### PR DESCRIPTION
Include options and lazy dependencies from the new command to the deprecated one.

I was sure that this was working already. But fur sure I was once again bit by [CHEF-3255](http://tickets.opscode.com/browse/CHEF-3255). :(
