### PR TITLE
Added support for RHEL based systems where /etc/issue is modified

### DIFF
--- a/lib/knife-solo/bootstraps/linux.rb
+++ b/lib/knife-solo/bootstraps/linux.rb
@@ -1,9 +1,12 @@
 module KnifeSolo::Bootstraps
   class Linux < Base
     def issue
-      prepare.run_command("cat /etc/redhat-release").stdout.strip || 
-      prepare.run_command("cat /etc/issue").stdout.strip || 
-      prepare.run_command("lsb_release -d -s").stdout.strip
+      cmds = [
+              "lsb_release -d -s",
+              "cat /etc/redhat-release",
+              "cat /etc/issue"
+      ]
+      prepare.run_command(cmds.join(" || ")).stdout.strip
     end
 
     def x86?


### PR DESCRIPTION
Modified issue() so that it looks at /etc/redhat-release first.
This was tested on RHEL, Oracle Linux and Ubuntu.
