### PR TITLE
Parse Chef version even if chef-solo command prints warnings

### DIFF
--- a/lib/chef/knife/solo_cook.rb
+++ b/lib/chef/knife/solo_cook.rb
@@ -294,8 +294,8 @@ class Chef
 
       # Parses "Chef: x.y.z" from the chef-solo version output
       def chef_version
-        v = run_command('sudo chef-solo --version').stdout.split(':')
-        v[0].strip == 'Chef' ? v[1].strip : ''
+        cmd = %q{sudo chef-solo --version 2>/dev/null | awk '$1 == "Chef:" {print $2}'}
+        run_command(cmd).stdout.strip
       end
 
       def cook

--- a/test/solo_cook_test.rb
+++ b/test/solo_cook_test.rb
@@ -221,13 +221,6 @@ class SoloCookTest < TestCase
     end
   end
 
-  def test_parses_chef_version_output
-    version_string = "\r\nChef: 11.2.0\r\n"
-    cmd = command("somehost")
-    cmd.stubs(:run_command).returns(OpenStruct.new(:stdout => version_string))
-    assert_equal '11.2.0', cmd.chef_version
-  end
-
   def test_barks_if_chef_too_old
     in_kitchen do
       cmd = command("somehost")


### PR DESCRIPTION
Fixes #235
