### PR TITLE
Add --no-check-certificate to wget when retrieving omnibus installer

### DIFF
--- a/lib/knife-solo/bootstraps.rb
+++ b/lib/knife-solo/bootstraps.rb
@@ -65,7 +65,7 @@ module KnifeSolo
           if command -v curl >/dev/null 2>&1; then
             curl -L -o #{file} #{url}
           else
-            wget -O #{file} #{url}
+            wget --no-check-certificate -O #{file} #{url}
           fi
         BASH
       end


### PR DESCRIPTION
On one of my debian box, I kept on getting the following error and can't go further when I do knife solo prepare:

--2013-05-07 01:01:05--  https://www.opscode.com/chef/install.sh
Resolving www.opscode.com... 184.106.28.82
Connecting to www.opscode.com|184.106.28.82|:443... connected.
ERROR: cannot verify www.opscode.com’s certificate, issued by “/C=US/O=DigiCert Inc/CN=DigiCert Secure Server CA”:
  Unable to locally verify the issuer’s authority.
To connect to www.opscode.com insecurely, use ‘--no-check-certificate’.
