### PR TITLE
Escape rsync exclude patterns

### DIFF
--- a/lib/chef/knife/solo_cook.rb
+++ b/lib/chef/knife/solo_cook.rb
@@ -154,6 +154,10 @@ class Chef
         adjust_rsync_path(path)
       end
 
+      def rsync_debug
+        '-v' if debug?
+      end
+
       # see http://stackoverflow.com/questions/5798807/rsync-permission-denied-created-directories-have-no-permissions
       def rsync_permissions
         '--chmod=ugo=rwX' if windows_client?
@@ -277,7 +281,7 @@ class Chef
       end
 
       def rsync(source_path, target_path, extra_opts = '--delete')
-        cmd = %Q{rsync -rl #{rsync_permissions} --rsh="ssh #{ssh_args}" #{extra_opts}}
+        cmd = %Q{rsync -rl #{rsync_debug} #{rsync_permissions} --rsh="ssh #{ssh_args}" #{extra_opts}}
         cmd << rsync_excludes.map { |ignore| " --exclude '#{ignore}'" }.join
         cmd << %Q{ #{adjust_rsync_path_on_client(source_path)} :#{adjust_rsync_path_on_node(target_path)}}
         Chef::Log.debug cmd


### PR DESCRIPTION
Unless properly quoted, the chefignore globs passed to rsync will expand in shell. And if they match multiple files all but the first will be uploaded to the node. By every rsync call. This can cause **a lot** of confusion and finally breaks things as solo.rb will be a directory containing the generated tempfile and some matched files.

While at it, I also split the rsync command construction to multiple lines and added `-v` option to rsync command if knife is run in debug mode.
