### PR TITLE
Switch all EC2 IPs to DNS

### DIFF
--- a/test/support/ec2_runner.rb
+++ b/test/support/ec2_runner.rb
@@ -39,7 +39,7 @@ class EC2Runner < MiniTest::Unit
     server.wait_for { ready? }
     logger.info "#{test.class} server (#{server.dns_name}) reported ready, trying to connect to ssh..."
     server.wait_for do
-      `nc #{public_ip_address} 22 -w 1 -q 0 </dev/null`
+      `nc #{dns_name} 22 -w 1 -q 0 </dev/null`
       $?.success?
     end
     logger.info "Sleeping 10s to avoid Net::SSH locking up by connecting too early..."
@@ -79,7 +79,7 @@ class EC2Runner < MiniTest::Unit
       end
       sleep 20
       servers.each do |server|
-        logger.info "Destroying #{server.public_ip_address}..."
+        logger.info "Destroying #{server.dns_name}..."
         server.destroy
       end
     end

--- a/test/support/integration_test.rb
+++ b/test/support/integration_test.rb
@@ -52,7 +52,7 @@ class IntegrationTest < TestCase
 
   # Writes out the given node hash as a json file
   def write_nodefile(node)
-    write_json_file("nodes/#{server.public_ip_address}.json", node)
+    write_json_file("nodes/#{server.dns_name}.json", node)
   end
 
   # Writes out an object to the given file as JSON
@@ -82,7 +82,7 @@ class IntegrationTest < TestCase
 
   # The ssh-style connection string used to connect to the current node
   def connection_string
-    "-i #{key_file} #{user}@#{server.public_ip_address}"
+    "-i #{key_file} #{user}@#{server.dns_name}"
   end
 
   # Asserts that a knife command is successful


### PR DESCRIPTION
This lets us avoid potential host key problems by putting this in
~/.ssh/config

```
Host *amazonaws.com
StrictHostKeyChecking no
```
