### PR TITLE
Adding option to use custom remote 'sudo' command

### DIFF
--- a/lib/knife-solo/ssh_command.rb
+++ b/lib/knife-solo/ssh_command.rb
@@ -56,7 +56,6 @@ module KnifeSolo
           :description => 'The startup script on the remote server containing variable definitions'
 
         option :sudo_command,
-          :short       => '-S SUDO_COMMAND',
           :long        => '--sudo-command SUDO_COMMAND',
           :description => 'The command to use instead of sudo for admin privileges'
 


### PR DESCRIPTION
I don't know if this will be useful to anyone else, but I added an option to ssh_command (`-S` or `--sudo-command`) that bypasses sudo detection and uses the supplied string instead. I'm using this to provision SmartOS/Solaris servers that use pfexec for admin privileges instead of sudo.
