### PR TITLE
AuthenticationFailed when password last char is space

### DIFF
--- a/lib/knife-solo/ssh_command.rb
+++ b/lib/knife-solo/ssh_command.rb
@@ -101,6 +101,7 @@ module KnifeSolo
     def ask_password
       ui.ask("Enter the password for #{user}@#{host}: ") do |q|
         q.echo = false
+        q.whitespace = :chomp
       end
     end
 


### PR DESCRIPTION
When the last character of the root password is ' '(blank), I can't login server.

```
$ knife solo cook example.com
Enter the password for root@example.com:
ERROR: Net::SSH::AuthenticationFailed: root
```
