### PR TITLE
knife-solo, environments and cookbook versions

### DIFF
--- a/lib/chef/knife/solo_cook.rb
+++ b/lib/chef/knife/solo_cook.rb
@@ -111,6 +111,7 @@ class Chef
         upload_to_provision_path(:role_path, 'roles')
         upload_to_provision_path(:data_bag_path, 'data_bags')
         upload_to_provision_path(:encrypted_data_bag_secret, 'data_bag_key')
+        upload_to_provision_path(:environments, 'environments')
       end
 
       def expand_path(path)

--- a/lib/chef/knife/solo_init.rb
+++ b/lib/chef/knife/solo_init.rb
@@ -32,7 +32,7 @@ class Chef
         validate!
         create_kitchen
         create_config
-        create_cupboards %w[nodes roles data_bags site-cookbooks cookbooks]
+        create_cupboards %w[nodes roles data_bags environments site-cookbooks cookbooks]
         gitignore %w[/cookbooks/]
         if (cm = cookbook_manager)
           cm.bootstrap(@base)

--- a/lib/knife-solo/resources/solo.rb.erb
+++ b/lib/knife-solo/resources/solo.rb.erb
@@ -4,6 +4,7 @@ nodes_path                File.join(base, 'nodes')
 role_path                 File.join(base, 'roles')
 data_bag_path             File.join(base, 'data_bags')
 encrypted_data_bag_secret File.join(base, 'data_bag_key')
+environment_path          File.join(base, 'environments')
 
 cookbook_path []
 <% cookbook_paths.each_with_index do |path, i| -%>


### PR DESCRIPTION
With a chef-server, I can have multiple version of a cookbook and specify in my environment which version should my run_list use.
Can I mimic the same behavior with knife solo ? If so, how ?
