### PR TITLE
implement a experimental ssh-keepalive feature #222

### DIFF
--- a/test/ssh_command_test.rb
+++ b/test/ssh_command_test.rb
@@ -149,6 +149,25 @@ class SshCommandTest < TestCase
     assert_equal 1, res.exit_code
   end
 
+  def test_handle_ssh_keepalive
+    cmd = command("usertest@10.0.0.1", "--ssh-keepalive=60")
+    cmd.validate_ssh_options!
+    assert_equal 60, cmd.keepalive_interval
+  end
+
+  def test_default_ssh_keepalive_is_nil
+    cmd = command("usertest@10.0.0.1")
+    cmd.validate_ssh_options!
+    assert_nil cmd.keepalive_interval
+  end
+
+  def test_barks_with_a_zero_value_of_ssh_keepalive
+    cmd = command("usertest@10.0.0.1", "--ssh-keepalive=59")
+    cmd.ui.expects(:err).with(regexp_matches(/--ssh-keepalive.*60/))
+    $stdout.stubs(:puts)
+    assert_exits { cmd.validate_ssh_options! }
+  end
+
   def result(code, stdout = "")
     res = KnifeSolo::SshCommand::ExecResult.new(code)
     res.stdout = stdout


### PR DESCRIPTION
I wrote a experimental implementation of the ssh keepalive using only the current net-ssh functionalities.

The point is:
1. Pass an integer value to the `ssh.loop` method. (It will be used as the IO.select 's fourth argument)
2. Add a on_process callback to send a SSH_MSG_IGNORE packet.
3. add '--ssh-keepalive=SECONDS' option to control the ssh keepalive behavior.

So, when the '--ssh-keepalive' option is specified, knife-solo will send a SSH_MSG_IGNORE packet at regular intervals. But when the '--ssh-keepalive' option is not specified, knife-solo's behavior is not changed.

This code would be avoid a knife-solo hang up issue like #222.
But I think that this is not a very good idea...
