### PR TITLE
Add --ssh-keepalive option to solve the issue of #222

### DIFF
--- a/knife-solo.gemspec
+++ b/knife-solo.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rdoc', '~> 3.12'
 
   s.add_dependency 'chef',     '>= 10.12'
-  s.add_dependency 'net-ssh',  '>= 2.2.2', '< 3.0'
+  s.add_dependency 'net-ssh',  '>= 2.7.0', '< 3.0'
   s.add_dependency 'erubis',   '~> 2.7.0'
 end

--- a/lib/knife-solo/ssh_command.rb
+++ b/lib/knife-solo/ssh_command.rb
@@ -53,9 +53,14 @@ module KnifeSolo
           :description => 'The ssh port'
 
         option :ssh_keepalive,
-          :long        => '--ssh-keepalive SECONDS',
+          :long        => '--[no-]ssh-keepalive',
+          :description => 'Use ssh keepalive',
+          :default     => true
+
+        option :ssh_keepalive_interval,
+          :long        => '--ssh-keepalive-interval SECONDS',
           :description => 'The ssh keepalive interval',
-          :default     => nil,
+          :default     => 300,
           :proc        => Proc.new { |v| v.to_i }
 
         option :startup_script,
@@ -80,10 +85,6 @@ module KnifeSolo
       @name_args.first =~ /\A([^@]+(?>@)[^@]+|[^@]+?(?!@))\z/
     end
 
-    def net_ssh_supports_keepalive?
-      Gem.loaded_specs['net-ssh'].version >= Gem::Version.create('2.7.0')
-    end
-
     def validate_ssh_options!
       if config[:ssh_identity]
         ui.warn '`--ssh-identity` is deprecated, please use `--identity-file`.'
@@ -97,15 +98,9 @@ module KnifeSolo
       if config[:ssh_user]
         host_descriptor[:user] ||= config[:ssh_user]
       end
-      if config[:ssh_keepalive]
-        unless net_ssh_supports_keepalive?
-          ui.fatal '`--ssh-keepalive` requires the net-ssh 2.7.0 or later'
-          exit 1
-        end
-        if config[:ssh_keepalive] <= 0
-          ui.fatal '`--ssh-keepalive` must be a positive number'
-          exit 1
-        end
+      if config[:ssh_keepalive_interval] <= 0
+        ui.fatal '`--ssh-keepalive-interval` must be a positive number'
+        exit 1
       end
     end
 
@@ -157,8 +152,8 @@ module KnifeSolo
         options[:user_known_hosts_file] = "/dev/null"
       end
       if config[:ssh_keepalive]
-        options[:keepalive] = true
-        options[:keepalive_interval] = config[:ssh_keepalive]
+        options[:keepalive] = config[:ssh_keepalive]
+        options[:keepalive_interval] = config[:ssh_keepalive_interval]
       end
       options
     end

--- a/test/ssh_command_test.rb
+++ b/test/ssh_command_test.rb
@@ -60,7 +60,7 @@ class SshCommandTest < TestCase
 
   def test_uses_default_keys_if_conncetion_succeeds
     cmd = command("10.0.0.1")
-    assert_equal({}, cmd.connection_options)
+    assert_equal({:keepalive => true, :keepalive_interval => 300}, cmd.connection_options)
   end
 
   def test_uses_ssh_config_if_matched
@@ -150,31 +150,27 @@ class SshCommandTest < TestCase
   end
 
   def test_handle_ssh_keepalive
-    Gem.loaded_specs['net-ssh'].stubs(:version).returns(Gem::Version.create('2.7.0'))
-    cmd = command("usertest@10.0.0.1", "--ssh-keepalive=300")
+    cmd = command("usertest@10.0.0.1", "--ssh-keepalive", '--ssh-keepalive-interval=100')
+    cmd.validate_ssh_options!
+    assert_equal true, cmd.connection_options[:keepalive]
+    assert_equal 100, cmd.connection_options[:keepalive_interval]
+  end
+
+  def test_handle_no_ssh_keepalive
+    cmd = command("usertest@10.0.0.1", "--no-ssh-keepalive")
+    assert_equal({}, cmd.connection_options)
+  end
+
+  def test_handle_default_ssh_keepalive_is_true
+    cmd = command("usertest@10.0.0.1")
     cmd.validate_ssh_options!
     assert_equal true, cmd.connection_options[:keepalive]
     assert_equal 300, cmd.connection_options[:keepalive_interval]
   end
 
-  def test_handle_default_ssh_keepalive_is_nil
-    cmd = command("usertest@10.0.0.1")
-    cmd.validate_ssh_options!
-    assert_nil cmd.connection_options[:keepalive]
-  end
-
   def test_barks_if_ssh_keepalive_is_zero
-    Gem.loaded_specs['net-ssh'].stubs(:version).returns(Gem::Version.create('2.7.0'))
-    cmd = command("usertest@10.0.0.1", "--ssh-keepalive=0")
-    cmd.ui.expects(:err).with(regexp_matches(/--ssh-keepalive.*positive number/))
-    $stdout.stubs(:puts)
-    assert_exits { cmd.validate_ssh_options! }
-  end
-
-  def test_barks_if_net_ssh_does_not_support_keepalive
-    Gem.loaded_specs['net-ssh'].stubs(:version).returns(Gem::Version.create('2.6.8'))
-    cmd = command("usertest@10.0.0.1", "--ssh-keepalive=300")
-    cmd.ui.expects(:err).with(regexp_matches(/--ssh-keepalive.*requires.*2\.7\.0/))
+    cmd = command("usertest@10.0.0.1", "--ssh-keepalive-interval=0")
+    cmd.ui.expects(:err).with(regexp_matches(/--ssh-keepalive-interval.*positive number/))
     $stdout.stubs(:puts)
     assert_exits { cmd.validate_ssh_options! }
   end


### PR DESCRIPTION
I sent a patch to support a keepalive feature to the net-ssh community, and it has been merged into the net-ssh 2.7.0.
So, I added a --ssh-keepalive option to solve the issue of #222.

Usage example:

```
knife solo cook --ssh-keepalive 300 <target-host>
```
