### PR TITLE
Follow symlinks when uploading kitchen

### DIFF
--- a/lib/chef/knife/solo_cook.rb
+++ b/lib/chef/knife/solo_cook.rb
@@ -243,7 +243,7 @@ class Chef
       end
 
       def rsync(source_path, target_path, extra_opts = '--delete')
-        cmd = %Q{rsync -rl #{rsync_debug} #{rsync_permissions} --rsh="ssh #{ssh_args}" #{extra_opts}}
+        cmd = %Q{rsync -rL #{rsync_debug} #{rsync_permissions} --rsh="ssh #{ssh_args}" #{extra_opts}}
         cmd << rsync_excludes.map { |ignore| " --exclude '#{ignore}'" }.join
         cmd << %Q{ #{adjust_rsync_path_on_client(source_path)} :#{adjust_rsync_path_on_node(target_path)}}
         Chef::Log.debug cmd


### PR DESCRIPTION
Now that the directory structure on the node is not the same than locally, the symlinks copied as is can result broken. So copy the destination of the symlink instead.

Fixes #279.
