### PR TITLE
Print an error if a `*_path` configuration is not a String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Follow symlinks when uploading kitchen ([279], [289])
 * Quote rsync paths to avoid problems with spaces in directory names ([281], [286])
 * Fix precedence of automatic cookbook_path components ([296], [298])
+* Print an error message if a `*_path` configuration value is not a String ([278], [300])
 
 ## Thanks to our contributors!
 
@@ -25,6 +26,7 @@
 [265]: https://github.com/matschaffer/knife-solo/issues/265
 [268]: https://github.com/matschaffer/knife-solo/issues/268
 [274]: https://github.com/matschaffer/knife-solo/issues/274
+[278]: https://github.com/matschaffer/knife-solo/issues/278
 [279]: https://github.com/matschaffer/knife-solo/issues/279
 [281]: https://github.com/matschaffer/knife-solo/issues/281
 [284]: https://github.com/matschaffer/knife-solo/issues/284
@@ -35,6 +37,7 @@
 [295]: https://github.com/matschaffer/knife-solo/issues/295
 [296]: https://github.com/matschaffer/knife-solo/issues/296
 [298]: https://github.com/matschaffer/knife-solo/issues/298
+[300]: https://github.com/matschaffer/knife-solo/issues/300
 
 # 0.3.0 / 2013-08-01
 

--- a/lib/chef/knife/solo_cook.rb
+++ b/lib/chef/knife/solo_cook.rb
@@ -111,9 +111,9 @@ class Chef
         run_portable_mkdir_p(provisioning_path, '0700')
 
         cookbook_paths.each_with_index do |path, i|
-          upload_to_provision_path(path, "/cookbooks-#{i + 1}", 'cookbook_path')
+          upload_to_provision_path(path.to_s, "/cookbooks-#{i + 1}", 'cookbook_path')
         end
-        upload_to_provision_path(node_config, 'dna.json')
+        upload_to_provision_path(node_config.to_s, 'dna.json')
         upload_to_provision_path(nodes_path, 'nodes')
         upload_to_provision_path(:role_path, 'roles')
         upload_to_provision_path(:data_bag_path, 'data_bags')
@@ -227,6 +227,8 @@ class Chef
 
         if src.nil?
           Chef::Log.debug "'#{key_name}' not set"
+        elsif !src.is_a?(String)
+          ui.error "#{key_name} is not a String: #{src.inspect}"
         elsif !File.exist?(src)
           ui.warn "Local #{key_name} '#{src}' does not exist"
         else


### PR DESCRIPTION
Fixes #278
