### PR TITLE
Pass sudo password hook to SshConnection

### DIFF
--- a/lib/knife-solo/ssh_command.rb
+++ b/lib/knife-solo/ssh_command.rb
@@ -229,7 +229,7 @@ module KnifeSolo
 
       output = ui.stdout if options[:streaming]
 
-      @connection ||= SshConnection.new(host, user, connection_options)
+      @connection ||= SshConnection.new(host, user, connection_options, method(:password))
       @connection.run_command(command, output)
     end
 

--- a/lib/knife-solo/ssh_connection.rb
+++ b/lib/knife-solo/ssh_connection.rb
@@ -23,16 +23,21 @@ module KnifeSolo
       end
     end
 
-    def initialize(host, user, connection_options)
+    def initialize(host, user, connection_options, sudo_password_hook)
       @host = host
       @user = user
       @connection_options = connection_options
+      @password_hook = sudo_password_hook
     end
 
     attr_reader :host, :user, :connection_options
 
     def session
       @session ||= Net::SSH.start(host, user, connection_options)
+    end
+
+    def password
+      @password ||= @password_hook.call
     end
 
     def run_command(command, output = nil)


### PR DESCRIPTION
Pass it as a hook instead of the value to avoid asking it from the user in case it is not needed.

Fixes #294
