### PR TITLE
Explicitly set root path for default `*_path` options

### DIFF
--- a/lib/knife-solo/node_config_command.rb
+++ b/lib/knife-solo/node_config_command.rb
@@ -43,6 +43,10 @@ module KnifeSolo
 
     def nodes_path
       path = Chef::Config[:node_path]
+      if path && !path.is_a?(String)
+        ui.error %Q{node_path is not a String: #{path.inspect}, defaulting to "nodes"}
+        path = nil
+      end
       path && File.exist?(path) ? path : 'nodes'
     end
 


### PR DESCRIPTION
Chef 11.8.0 (with mixlib-config 2.0) sets `*_path` options by default based on `cookbook_path`. If it is an array (as always in knife-solo), the other paths are also arrays. And after #300 we'll catch that and error out.

Workaround is to explicitly specify all paths in _.chef/knife.rb_. Or add this:

``` rb
chef_repo_path "."
```

While the conversion to Array is partly a regression in Chef itself (I'll file a ticket soon), we anyway want to set the default path relative to our kitchen root, as `cookbook_path` components might be pointing to somewhere else.
## 

This PR also adds verification that `node_path` is a String. `node_path` made it back to Chef's default configuration in 11.8.0. And as pre 0.3.0 setups won't normally have it explicitly configured, it defaults to being an Array.

Also a user might set it to be an Array, which leads knife-solo crashing with the infamous `ERROR: TypeError: no implicit conversion of Array into String`. This escaped from us in #300.
