### PR TITLE
Test against Chef master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,7 @@ rvm:
 gemfile:
   - test/gemfiles/Gemfile.chef-11
   - test/gemfiles/Gemfile.chef-10
+  - test/gemfiles/Gemfile.chef-master
+matrix:
+  allow_failures:
+    - gemfile: test/gemfiles/Gemfile.chef-master

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -37,6 +37,7 @@ test/bootstraps_test.rb
 test/deprecated_command_test.rb
 test/gemfiles/Gemfile.chef-10
 test/gemfiles/Gemfile.chef-11
+test/gemfiles/Gemfile.chef-master
 test/gitignore_test.rb
 test/integration/amazon_linux_2012_09_bootstrap_test.rb
 test/integration/cases/apache2_bootstrap.rb

--- a/test/gemfiles/Gemfile.chef-master
+++ b/test/gemfiles/Gemfile.chef-master
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec :path => '../..'
+
+gem 'chef', github: 'opscode/chef'


### PR DESCRIPTION
We should add Travis test against Chef master branch. And maybe Berkshelf too as it is very different to v2.0. The "bleeding edge" test can be marked as ignored in case of failure.
