### PR TITLE
added support for Oracle Linux

### DIFF
--- a/lib/knife-solo/bootstraps/linux.rb
+++ b/lib/knife-solo/bootstraps/linux.rb
@@ -79,6 +79,8 @@ module KnifeSolo::Bootstraps
         {:type => "yum_omnibus"}
       when %r{Red Hat Enterprise}
         {:type => "yum_omnibus"}
+      when %r{Enterprise Linux Enterprise Linux Server}
+        {:type => "yum_omnibus"}
       when %r{Fedora release}
         {:type => "yum_omnibus"}
       when %r{Scientific Linux}


### PR DESCRIPTION
Patch has been tested on oracle linux 5.10

```
[chef]$ lsb_release -d -s
"Enterprise Linux Enterprise Linux Server release 5.10 (Carthage)"
```

Fixes #310
