### PR TITLE
Add wget to omnibus install.

### DIFF
--- a/lib/knife-solo/bootstraps/linux.rb
+++ b/lib/knife-solo/bootstraps/linux.rb
@@ -45,7 +45,7 @@ module KnifeSolo::Bootstraps
 
     def debianoid_omnibus_install
       run_command("sudo apt-get update")
-      run_command("sudo apt-get -y install rsync ca-certificates")
+      run_command("sudo apt-get -y install rsync ca-certificates wget")
       omnibus_install
     end
 


### PR DESCRIPTION
On debootstraped machines i have error on `knife solo prepare`.
It search for wget but it missing in OS.
