### PR TITLE
Change rsync option from --delete to --delete-after to resolve the --del...

### DIFF
--- a/lib/chef/knife/solo_cook.rb
+++ b/lib/chef/knife/solo_cook.rb
@@ -246,7 +246,7 @@ class Chef
         file.unlink
       end
 
-      def rsync(source_path, target_path, extra_opts = '--delete')
+      def rsync(source_path, target_path, extra_opts = '--delete-after')
         cmd = ['rsync', '-rL', rsync_debug, rsync_permissions, %Q{--rsh=ssh #{ssh_args}}, extra_opts]
         cmd += rsync_excludes.map { |ignore| "--exclude=#{ignore}" }
         cmd << adjust_rsync_path_on_client(source_path)


### PR DESCRIPTION
delete-during issue

Resolving Rsync 3.0.7+ error

FATAL I/O ERROR: dying to avoid a --delete-during issue with a pre-3.0.7 receiver.
rsync error: requested action not supported (code 4) at flist.c(1947) [sender=3.1.0]

rsync version on workstation is 3.1.0
rsync version on node 3.0.6
