### PR TITLE
Support for Ohai hints

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -48,6 +48,7 @@ test/integration/cases/empty_cook.rb
 test/integration/cases/encrypted_data_bag.rb
 test/integration/cases/environment.rb
 test/integration/cases/knife_bootstrap.rb
+test/integration/cases/ohai_hints.rb
 test/integration/centos5_8_test.rb
 test/integration/centos6_3_test.rb
 test/integration/debian6_bootstrap_test.rb
@@ -58,6 +59,7 @@ test/integration/scientific_linux_63_test.rb
 test/integration/sles_11_test.rb
 test/integration/ubuntu10_04_test.rb
 test/integration/ubuntu12_04_bootstrap_test.rb
+test/integration/ubuntu12_04_ohai_hints_test.rb
 test/integration/ubuntu12_04_test.rb
 test/integration_helper.rb
 test/knife_bootstrap_test.rb

--- a/lib/chef/knife/solo_prepare.rb
+++ b/lib/chef/knife/solo_prepare.rb
@@ -39,6 +39,14 @@ class Chef
         :long        => '--omnibus-version VERSION',
         :description => 'Deprecated. Replaced with --bootstrap-version.'
 
+      option :hint,
+        :long        => '--hint HINT_NAME[=HINT_FILE]',
+        :description => 'Specify Ohai Hint to be set on the bootstrap target.  Use multiple --hint options to specify multiple hints.',
+        :proc        => Proc.new { |h|
+          Chef::Config[:knife][:hints] ||= Hash.new
+          name, path = h.split("=")
+          Chef::Config[:knife][:hints][name] = path ? JSON.parse(::File.read(path)) : Hash.new  }
+
       def run
         if config[:omnibus_version]
           ui.warn '`--omnibus-version` is deprecated, please use `--bootstrap-version`.'

--- a/lib/knife-solo/bootstraps.rb
+++ b/lib/knife-solo/bootstraps.rb
@@ -48,6 +48,7 @@ module KnifeSolo
 
       def bootstrap!
         run_pre_bootstrap_checks
+        install_ohai_hints
         send("#{distro[:type]}_install")
       end
 
@@ -107,6 +108,17 @@ module KnifeSolo
           "--prerelease"
         elsif chef_version
           "--version #{chef_version}"
+        end
+      end
+
+      def install_ohai_hints
+        hints = KnifeSolo::Tools.config_value(prepare.config, :hints)
+        unless hints.nil? || hints.empty?
+          ui.msg "Setting Ohai hints..."
+          run_command("sudo mkdir -p /etc/chef/ohai/hints")
+          hints.each do |name, hash|
+            run_command("sudo tee -a /etc/chef/ohai/hints/#{name}.json > /dev/null <<EOF\n#{hash.to_json}\nEOF\n")
+          end
         end
       end
     end #InstallCommands

--- a/lib/knife-solo/bootstraps.rb
+++ b/lib/knife-solo/bootstraps.rb
@@ -48,8 +48,8 @@ module KnifeSolo
 
       def bootstrap!
         run_pre_bootstrap_checks
-        install_ohai_hints
         send("#{distro[:type]}_install")
+        install_ohai_hints
       end
 
       def distro
@@ -112,7 +112,7 @@ module KnifeSolo
       end
 
       def install_ohai_hints
-        hints = KnifeSolo::Tools.config_value(prepare.config, :hints)
+        hints = Chef::Config[:knife][:hints]
         unless hints.nil? || hints.empty?
           ui.msg "Setting Ohai hints..."
           run_command("sudo mkdir -p /etc/chef/ohai/hints")

--- a/lib/knife-solo/bootstraps.rb
+++ b/lib/knife-solo/bootstraps.rb
@@ -116,6 +116,7 @@ module KnifeSolo
         unless hints.nil? || hints.empty?
           ui.msg "Setting Ohai hints..."
           run_command("sudo mkdir -p /etc/chef/ohai/hints")
+          run_command("sudo rm -f /etc/chef/ohai/hints/*")
           hints.each do |name, hash|
             run_command("sudo tee -a /etc/chef/ohai/hints/#{name}.json > /dev/null <<EOF\n#{hash.to_json}\nEOF\n")
           end

--- a/test/integration/cases/ohai_hints.rb
+++ b/test/integration/cases/ohai_hints.rb
@@ -1,0 +1,33 @@
+# Tries to bootstrap with --hint option and
+# verifies ohai hints get written properly.
+
+module OhaiHints
+  def prepare_hints(hints)
+    hints.map { |name, data|
+      if data.nil?
+        "--hint #{name}"
+      else
+        File.open("#{name}.json", "wb") { |f| f.write(data) }
+        "--hint #{name}=#{name}.json"
+      end
+    }.join(' ')
+  end
+
+  def check_hints(hints)
+    hints.each do |name, data|
+      actual = `ssh #{connection_string} cat /etc/chef/ohai/hints/#{name}.json`
+      assert_match actual.strip, data.nil? ? '{}' : data
+    end
+  end
+
+  def test_ohai_hints
+    hints = {
+      'test_hint_1' => '{"foo":"bar"}',
+      'test_hint_2' => nil
+    }
+
+    hint_opts = prepare_hints(hints)
+    assert_subcommand "bootstrap #{hint_opts}" 
+    check_hints(hints)
+  end
+end

--- a/test/integration/ubuntu12_04_ohai_hints_test.rb
+++ b/test/integration/ubuntu12_04_ohai_hints_test.rb
@@ -1,0 +1,17 @@
+require 'integration_helper'
+
+class Ubuntu12_04OhaiHintsTest < IntegrationTest
+  def user
+    "ubuntu"
+  end
+
+  def image_id
+    "ami-9a873ff3"
+  end
+
+  def prepare_server
+    # Do nothing as `solo bootstrap` will do everything
+  end
+
+  include OhaiHints
+end


### PR DESCRIPTION
This patch adds support for writing Ohai hints to the machine during bootstrap. The knife bootstrap code does this in https://github.com/opscode/chef/blob/master/lib/chef/knife/bootstrap/chef-full.erb

`knife ec2` and friends can be used to set hints but we also add a --hint option to `knife solo prepare` in order to use it with instances that have already been created.

The code is currently run directly from bootstrap! which might not be ideal. Is there a better place to put it?