### PR TITLE
Add --forward-agent support

### DIFF
--- a/lib/knife-solo/ssh_command.rb
+++ b/lib/knife-solo/ssh_command.rb
@@ -47,6 +47,12 @@ module KnifeSolo
           :long        => '--identity-file FILE',
           :description => 'The ssh identity file'
 
+        option :forward_agent,
+          :long        => '--forward-agent',
+          :description => 'Forward SSH authentication',
+          :boolean     => true,
+          :default     => false
+
         option :ssh_port,
           :short       => '-p PORT',
           :long        => '--ssh-port PORT',
@@ -132,6 +138,7 @@ module KnifeSolo
       options[:port] = config[:ssh_port] if config[:ssh_port]
       options[:password] = config[:ssh_password] if config[:ssh_password]
       options[:keys] = [config[:identity_file]] if config[:identity_file]
+      options[:forward_agent] = true if config[:forward_agent]
       if !config[:host_key_verify]
         options[:paranoid] = false
         options[:user_known_hosts_file] = "/dev/null"
@@ -163,12 +170,13 @@ module KnifeSolo
       host_arg = [user, host].compact.join('@')
       config_arg = "-F #{config[:ssh_config]}" if config[:ssh_config]
       ident_arg = "-i #{config[:identity_file]}" if config[:identity_file]
+      forward_arg = "-o ForwardAgent=yes" if config[:forward_agent]
       port_arg = "-p #{config[:ssh_port]}" if config[:ssh_port]      
       knownhosts_arg  =  "-o UserKnownHostsFile=#{connection_options[:user_known_hosts_file]}" if config[:host_key_verify] == false
       stricthosts_arg = "-o StrictHostKeyChecking=no" if config[:host_key_verify] == false
 
 
-      [host_arg, config_arg, ident_arg, port_arg, knownhosts_arg, stricthosts_arg].compact.join(' ')
+      [host_arg, config_arg, ident_arg, forward_arg, port_arg, knownhosts_arg, stricthosts_arg].compact.join(' ')
     end
 
     def sudo_command

--- a/test/ssh_command_test.rb
+++ b/test/ssh_command_test.rb
@@ -89,6 +89,11 @@ class SshCommandTest < TestCase
     assert_equal "/dev/null",  cmd.connection_options[:user_known_hosts_file]
   end
 
+  def test_handle_forward_agent
+    cmd = command("10.0.0.1", "--forward-agent")
+    assert_equal true,  cmd.connection_options[:forward_agent]
+  end
+
   def test_handle_default_host_key_verify_is_paranoid
     cmd = command("10.0.0.1")
     assert_nil(cmd.connection_options[:paranoid]) # Net:SSH default is :paranoid => true
@@ -120,6 +125,10 @@ class SshCommandTest < TestCase
     cmd = command("usertest@10.0.0.1", "--no-host-key-verify")
     cmd.validate_ssh_options!
     assert_equal "usertest@10.0.0.1 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no", cmd.ssh_args
+
+    cmd = command("usertest@10.0.0.1", "--forward-agent")
+    cmd.validate_ssh_options!
+    assert_equal "usertest@10.0.0.1 -o ForwardAgent=yes", cmd.ssh_args
   end
 
   def test_barks_without_atleast_a_hostname


### PR DESCRIPTION
Net::Ssh supports forward agent. Expose it to knife-solo with the `--forward-agent` flag.

Most useful with `--sudo-command "sudo -E"` so the environment variable pointing to the socket remains intact during chef run.
