### PR TITLE
explicitly execute bash script in bash

### DIFF
--- a/lib/knife-solo/bootstraps.rb
+++ b/lib/knife-solo/bootstraps.rb
@@ -62,7 +62,13 @@ module KnifeSolo
 
       def http_client_get_url(url, file)
         stream_command <<-BASH
-          /bin/sh -c "if command -v curl >/dev/null 2>&1; then curl -L -o '#{file}' '#{url}'; else wget -O '#{file}' '#{url}'; fi"
+          /bin/sh -c " \
+            if command -v curl >/dev/null 2>&1; then \
+              curl -L -o '#{file}' '#{url}'; \
+            else \
+              wget -O '#{file}' '#{url}'; \
+            fi; \
+          "
         BASH
       end
 


### PR DESCRIPTION
Fix for Issue https://github.com/matschaffer/knife-solo/issues/350 

I put the if/else block on one line to give the best possibility of whatever random shell on the client passing the whole command string on to bash.  In my testing, csh seems to have the most trouble with multiline strings.  I'm not familiar enough with it to know if there is a cleaner way to send the command string through to bash.

I hardcoded /bin/sh as the shell because the opscode install.sh script already depends on /bin/sh.
