### PR TITLE
Add node_name based on host to solo.rb

### DIFF
--- a/lib/knife-solo/resources/solo.rb.erb
+++ b/lib/knife-solo/resources/solo.rb.erb
@@ -1,3 +1,5 @@
+node_name <%= host.inspect %>
+
 base = File.expand_path('..', __FILE__)
 
 nodes_path                File.join(base, 'nodes')


### PR DESCRIPTION
This pull-request adds node_name to solo.rb based on host given to knife solo.

It's useful among other things to automatically setup hostname and fqdn. All you need is to add hostname cookbook to run-list and use knife solo with this pull-request.
