### PR TITLE
Update berkshelf.rb

### DIFF
--- a/lib/knife-solo/berkshelf.rb
+++ b/lib/knife-solo/berkshelf.rb
@@ -40,7 +40,7 @@ module KnifeSolo
     end
 
     def initial_config
-      'site :opscode'
+      "source 'https://api.berkshelf.com'"
     end
   end
 end


### PR DESCRIPTION
'site :opscode' has been deprecated in Berkshelf 3, see
https://github.com/berkshelf/berkshelf/wiki/deprecated-locations
