### PR TITLE
Allow ssl_verify_mode to be configured

### DIFF
--- a/lib/chef/knife/solo_cook.rb
+++ b/lib/chef/knife/solo_cook.rb
@@ -127,6 +127,10 @@ class Chef
         upload_to_provision_path(:environment_path, 'environments')
       end
 
+      def ssl_verify_mode
+        Chef::Config[:ssl_verify_mode] || :verify_peer
+      end
+
       def expand_path(path)
         Pathname.new(path).expand_path
       end

--- a/lib/knife-solo/resources/solo.rb.erb
+++ b/lib/knife-solo/resources/solo.rb.erb
@@ -6,6 +6,7 @@ data_bag_path             File.join(base, 'data_bags')
 encrypted_data_bag_secret File.join(base, 'data_bag_key')
 environment_path          File.join(base, 'environments')
 environment               <%= node_environment.inspect %>
+ssl_verify_mode           <%= ssl_verify_mode.inspect %>
 
 cookbook_path []
 <% cookbook_paths.each_with_index do |path, i| -%>

--- a/test/solo_cook_test.rb
+++ b/test/solo_cook_test.rb
@@ -34,6 +34,16 @@ class SoloCookTest < TestCase
     end
   end
 
+  def test_sets_ssl_verify_mode_returns_verify_peer_for_nil
+    Chef::Config[:ssl_verify_mode] = nil
+    assert_equal :verify_peer, command.ssl_verify_mode
+  end
+
+  def test_sets_ssl_verify_mode
+    Chef::Config[:ssl_verify_mode] = :verify_none
+    assert_equal :verify_none, command.ssl_verify_mode
+  end
+
   def test_expanded_config_paths_returns_empty_array_for_nil
     Chef::Config[:foo] = nil
     assert_equal [], command.expanded_config_paths(:foo)


### PR DESCRIPTION
In Chef 11.12.0+, [insecure SSL verification mode triggers a warning](https://github.com/opscode/chef/blob/11-stable/RELEASE_NOTES.md#unsecure-ssl-verification-mode-now-triggers-a-warning) like this:

``````
SSL validation of HTTPS requests is disabled. HTTPS connections are still
encrypted, but chef is not able to detect forged replies or man in the middle
attacks.

To fix this issue add an entry like this to your configuration file:

```
  # Verify all HTTPS connections (recommended)
  ssl_verify_mode :verify_peer

  # OR, Verify only connections to chef-server
  verify_api_cert true
```

To check your SSL configuration, or troubleshoot errors, you can use the
`knife ssl check` command like so:

```
  knife ssl check -c /home/vagrant/chef-solo/solo.rb
```
``````

This pull request allows `ssl_verify_mode` to be configured.

When not configured, it defaults to `:verify_peer` to prevent the above warning. :smile: 
