### PR TITLE
Do not upload nodes to remote host

### DIFF
--- a/lib/chef/knife/solo_cook.rb
+++ b/lib/chef/knife/solo_cook.rb
@@ -121,7 +121,6 @@ class Chef
         end
         upload_to_provision_path(node_config.to_s, 'dna.json')
         upload_to_provision_path(nodes_path, 'nodes')
-        upload_to_provision_path(:role_path, 'roles')
         upload_to_provision_path(:data_bag_path, 'data_bags')
         upload_to_provision_path(:encrypted_data_bag_secret, 'data_bag_key')
         upload_to_provision_path(:environment_path, 'environments')

--- a/lib/chef/knife/solo_cook.rb
+++ b/lib/chef/knife/solo_cook.rb
@@ -120,7 +120,7 @@ class Chef
           upload_to_provision_path(path.to_s, "/cookbooks-#{i + 1}", 'cookbook_path')
         end
         upload_to_provision_path(node_config.to_s, 'dna.json')
-        upload_to_provision_path(nodes_path, 'nodes')
+        upload_to_provision_path(:role_path, 'roles')
         upload_to_provision_path(:data_bag_path, 'data_bags')
         upload_to_provision_path(:encrypted_data_bag_secret, 'data_bag_key')
         upload_to_provision_path(:environment_path, 'environments')


### PR DESCRIPTION
This PR is a possible solution for: https://github.com/matschaffer/knife-solo/issues/374

It removes the line that copies the `node/` directory from the local kitchen to the remote host. So no sensitive data from other hosts might be copied over to hosts you do not intend.