### PR TITLE
Update source location for Berkshelf 3.0

### DIFF
--- a/lib/knife-solo/berkshelf.rb
+++ b/lib/knife-solo/berkshelf.rb
@@ -40,8 +40,7 @@ module KnifeSolo
     end
 
     def initial_config
-      berkshelf_version = ::Berkshelf::VERSION rescue nil
-      if berkshelf_version && Gem::Version.new(berkshelf_version) >= Gem::Version.new("3.0.0")
+      if defined?(::Berkshelf) && Gem::Version.new(::Berkshelf::VERSION) >= Gem::Version.new("3.0.0")
         'source "https://api.berkshelf.com"'
       else
         'site :opscode'


### PR DESCRIPTION
It seems changed from 3.0.0 (https://github.com/berkshelf/berkshelf/commit/90019cbfc23c3bd0c22d0eb1276226d71cf0eabe).
