### PR TITLE
Only sudo -E when using --forward-agent

### DIFF
--- a/lib/knife-solo/ssh_command.rb
+++ b/lib/knife-solo/ssh_command.rb
@@ -54,7 +54,7 @@ module KnifeSolo
 
         option :forward_agent,
           :long        => '--forward-agent',
-          :description => 'Forward SSH authentication',
+          :description => 'Forward SSH authentication. Adds -E to sudo, override with --sudo-command.',
           :boolean     => true,
           :default     => false
 


### PR DESCRIPTION
My take on fixing #358 by making -E context-dependent on if agent forwarding is enabled.  This seems to match @matschaffer's earler comment about making -E automatic when using --forward-agent, and addresses @andoq's issue by not using -E always.
