### PR TITLE
display cmd string on running chef-solo command

### DIFF
--- a/lib/chef/knife/solo_cook.rb
+++ b/lib/chef/knife/solo_cook.rb
@@ -302,7 +302,7 @@ class Chef
         cmd << " -W" if config[:why_run]
         cmd << " -o #{config[:override_runlist]}" if config[:override_runlist]
 
-        ui.msg "Running Chef... '#{cmd}'"
+        ui.msg "Running Chef: #{cmd}"
 
         result = stream_command cmd
         raise "chef-solo failed. See output above." unless result.success?


### PR DESCRIPTION
Chef/Knife newbies do try and error  many times, so showing what's happing is very important for newbies.
