### PR TITLE
enable --format (shortly -f) option.

### DIFF
--- a/lib/chef/knife/solo_cook.rb
+++ b/lib/chef/knife/solo_cook.rb
@@ -63,6 +63,11 @@ class Chef
         :long        => '--override-runlist',
         :description => 'Replace current run list with specified items'
 
+      option :format,
+        :short       => '-f FORMATTER',
+        :long        => '--format FORMATTER',
+        :description => 'output format to use'
+
       option :provisioning_path,
         :long        => '--provisioning-path path',
         :description => 'Where to store kitchen data on the node'
@@ -302,6 +307,7 @@ class Chef
         cmd << " -N #{config[:chef_node_name]}" if config[:chef_node_name]
         cmd << " -W" if config[:why_run]
         cmd << " -o #{config[:override_runlist]}" if config[:override_runlist]
+        cmd << " -F #{config[:format]}" if config[:format]
 
         result = stream_command cmd
         raise "chef-solo failed. See output above." unless result.success?


### PR DESCRIPTION
I guess current "--format" option does nothing.

For the short name, -F is desirable but used already, so use -f  instead.


