### PR TITLE
explain that the second argument JSON is a FILE.

### DIFF
--- a/lib/chef/knife/solo_cook.rb
+++ b/lib/chef/knife/solo_cook.rb
@@ -26,7 +26,7 @@ class Chef
         KnifeSolo::NodeConfigCommand.load_deps
       end
 
-      banner "knife solo cook [USER@]HOSTNAME [JSON] (options)"
+      banner "knife solo cook [USER@]HOSTNAME [JSONFILE] (options)"
 
       option :chef_check,
         :long        => '--no-chef-check',


### PR DESCRIPTION
I and my colleagues tried something like
`knife solo cook host1 '{"foo":"bar"}` 
and it does not work.

So I think describing that it expects a file is helpful for newbies.


