### PR TITLE
swap cookbooks in path to benefit cookbook create

### DIFF
--- a/lib/knife-solo/resources/knife.rb
+++ b/lib/knife-solo/resources/knife.rb
@@ -1,4 +1,4 @@
-cookbook_path    ["cookbooks", "site-cookbooks"]
+cookbook_path    ["site-cookbooks", "cookbooks"]
 node_path        "nodes"
 role_path        "roles"
 environment_path "environments"


### PR DESCRIPTION
this causes `knife cookbook create` to use `site-cookbooks` instead of `cookbooks`
