### PR TITLE
ssl_verify_mode :verify_peer by default in knife.rb

### DIFF
--- a/lib/knife-solo/resources/knife.rb
+++ b/lib/knife-solo/resources/knife.rb
@@ -6,3 +6,4 @@ data_bag_path    "data_bags"
 #encrypted_data_bag_secret "data_bag_key"
 
 knife[:berkshelf_path] = "cookbooks"
+Chef::Config[:ssl_verify_mode] = :verify_peer if defined? ::Chef


### PR DESCRIPTION
It looks like `knife solo cook` [tries to do this](https://github.com/matschaffer/knife-solo/blob/7f9f69da5e1afba90648c3f0b4e9bbc1ef244d3e/lib/chef/knife/solo_cook.rb#L130) as of #363, but since [the default in chef < 12 is `:verify_none`](https://github.com/opscode/chef/blob/6f57f82caaa1989fe9a6a3de3a4b7fa483f24684/lib/chef/config.rb#L363) that doesn't work. The `if defined? ::Chef` bit is courtesy of berkshelf's reimplementation of the Chef DSL, which will throw an exception otherwise.

With Chef 12 on the horizon this may be of limited use, but since I've been using this for a while I figure other people will find this useful. (Though, if you're a terrible person and TLS verification won't work in your environment, it will be more obvious how to turn it off.)
