### PR TITLE
Fix don't copy https_proxy_*** to solo.rb.

### DIFF
--- a/lib/chef/knife/solo_cook.rb
+++ b/lib/chef/knife/solo_cook.rb
@@ -148,7 +148,7 @@ class Chef
       end
 
       def proxy_setting_keys
-        [:http_proxy, :https_proxy, :http_proxy_user, :http_proxy_pass, :no_proxy]
+        [:http_proxy, :https_proxy, :http_proxy_user, :http_proxy_pass, :https_proxy_user, :https_proxy_pass, :no_proxy]
       end
 
       def proxy_settings


### PR DESCRIPTION
Proxy settings to solo.rb is copied from .chef/knife.rb with `knife solo cook host`. But, don't copy `https_proxy_user` and `https_proxy_pass`.

```
client:$ cat .chef/knife.rb
cookbook_path    ["cookbooks", "site-cookbooks"]
node_path        "nodes"
role_path        "roles"
environment_path "environments"
data_bag_path    "data_bags"
#encrypted_data_bag_secret "data_bag_key"

knife[:berkshelf_path] = "cookbooks"

http_proxy "http://proxy.server.com:3128/"
http_proxy_user "http_user"
http_proxy_pass "http_pass"
https_proxy "http://https.proxy.server.com:3128/"
https_proxy_user "https_user"
https_proxy_pass "https_pass"
```

After run `knife solo cook host`.

```
host:$ cat chef-solo/solo.rb
node_name "nodejs"

base = File.expand_path('..', __FILE__)

nodes_path                File.join(base, 'nodes')
role_path                 File.join(base, 'roles')
data_bag_path             File.join(base, 'data_bags')
encrypted_data_bag_secret File.join(base, 'data_bag_key')
environment_path          File.join(base, 'environments')
environment               "_default"
ssl_verify_mode           :verify_none

cookbook_path []
cookbook_path << File.join(base, 'cookbooks-1') # /var/lib/gems/1.9.1/gems/knife-solo-0.4.2/lib/knife-solo/resources/patch_cookbooks
cookbook_path << File.join(base, 'cookbooks-2') # /home/directory/documents/tmp/chefrepo/cookbooks
cookbook_path << File.join(base, 'cookbooks-3') # /home/directory/documents/tmp/chefrepo/site-cookbooks

http_proxy     "http://proxy.server.com:3128/"
https_proxy     "http://https.proxy.server.com:3128/"
http_proxy_user     "http_user"
http_proxy_pass     "http_pass"
```