### PR TITLE
Changing cookbook_path precedence

### DIFF
--- a/lib/knife-solo/resources/knife.rb
+++ b/lib/knife-solo/resources/knife.rb
@@ -1,4 +1,4 @@
-cookbook_path    ["cookbooks", "site-cookbooks"]
+cookbook_path    ["site-cookbooks", "cookbooks"]
 node_path        "nodes"
 role_path        "roles"
 environment_path "environments"


### PR DESCRIPTION
`site-cookbooks` contains user creations which must override `cookbooks`. Hence requesting this change in default knife.rb
```
["site-cookbooks", "cookbooks"]
```
This `site-cookbooks` should take precedence by default so that a new user using `knife cookbook create xyz` should find that `xyz` cookbook created in `site-cookbooks` folder not in `cookbooks`. 

Thank you.