### PR TITLE
add sudo to curl and wget commands

### DIFF
--- a/lib/knife-solo/bootstraps.rb
+++ b/lib/knife-solo/bootstraps.rb
@@ -63,10 +63,10 @@ module KnifeSolo
       def http_client_get_url(url, file)
         stream_command <<-BASH
           /bin/sh -c " \
-            if command -v curl >/dev/null 2>&1; then \
-              curl -L -o '#{file}' '#{url}'; \
+            if command -v sudo curl >/dev/null 2>&1; then \
+              sudo curl -L -o '#{file}' '#{url}'; \
             else \
-              wget -O '#{file}' '#{url}'; \
+              sudo wget -O '#{file}' '#{url}'; \
             fi; \
           "
         BASH


### PR DESCRIPTION
When the default host image has access to `wget` restricted, `knife solo bootstrap` fails with a permission error. I added `sudo` to the `wget` and `curl` commands so that bootstrapping will succeed in these cases.