### PR TITLE
Use omnibus installer for debian x86.

### DIFF
--- a/lib/knife-solo/bootstraps/linux.rb
+++ b/lib/knife-solo/bootstraps/linux.rb
@@ -70,7 +70,7 @@ module KnifeSolo::Bootstraps
     def distro
       return @distro if @distro
       @distro = case issue
-      when %r{Debian GNU/Linux [67]}
+      when %r{Debian GNU/Linux [678]}
         {:type => (x86? ? "debianoid_omnibus" : "debianoid_gem")}
       when %r{Debian}
         {:type => "debianoid_gem"}


### PR DESCRIPTION
I could add another case if we don't want this to apply to all debian.