### PR TITLE
use node name where passed from command line

### DIFF
--- a/lib/knife-solo/resources/solo.rb.erb
+++ b/lib/knife-solo/resources/solo.rb.erb
@@ -1,4 +1,4 @@
-node_name <%= host.inspect %>
+node_name <%= node_name.inspect %>
 
 base = File.expand_path('..', __FILE__)
 


### PR DESCRIPTION
otherwise node name follows host, which may have been passed as ip address, and the node name passed on the command line is completely ignored.