### PR TITLE
Fix gem-based bootstrap on Ubuntu 14.04 and up

### DIFF
--- a/lib/knife-solo/bootstraps/linux.rb
+++ b/lib/knife-solo/bootstraps/linux.rb
@@ -41,11 +41,16 @@ module KnifeSolo::Bootstraps
       run_command("sudo apt-get update")
 
       ui.msg "Installing required packages..."
-      @packages = %w(ruby ruby-dev libopenssl-ruby irb
+      @packages = %w(ruby ruby-dev libruby irb
                      build-essential wget ssl-cert rsync)
-      run_command <<-BASH
+      result = run_command <<-BASH
         sudo DEBIAN_FRONTEND=noninteractive apt-get --yes install #{package_list}
       BASH
+
+      if result.exit_code != 0
+        ui.fatal "Failed to install packages. Try installing them manually: #{@packages.join(' ')}"
+        exit 1
+      end
 
       gem_install
     end


### PR DESCRIPTION
Fixes #373 - I was setting up another machine and finally took the time to fix the script.

`libopenssl-ruby` and `libopenssl-ruby1.9` are both virtual packages, meaning they don't contain any files, and only instruct apt to install `libruby`, which is the real package. And, unlike the virtual packages, it has available on both older and newer (>14.04) systems.

I've also added a check that the package installation had succeeded.