### PR TITLE
Resolves #455 Add support for mac os x 10.10

### DIFF
--- a/lib/knife-solo/bootstraps/darwin.rb
+++ b/lib/knife-solo/bootstraps/darwin.rb
@@ -7,7 +7,7 @@ module KnifeSolo::Bootstraps
 
     def distro
       case issue
-      when %r{10.[6-10]}
+      when %r{10.(?:[6-9]|10)}
         {:type => 'omnibus'}
       else
         raise "OS X version #{issue} not supported"

--- a/lib/knife-solo/bootstraps/darwin.rb
+++ b/lib/knife-solo/bootstraps/darwin.rb
@@ -7,7 +7,7 @@ module KnifeSolo::Bootstraps
 
     def distro
       case issue
-      when %r{10.[6-9]}
+      when %r{10.[6-10]}
         {:type => 'omnibus'}
       else
         raise "OS X version #{issue} not supported"


### PR DESCRIPTION
The lastest chef [omnibus installer](https://downloads.chef.io/chef-client/mac/) supports mac os 10.10.

- Modified the omnibus darwin distro regex to add support for 10.6 - 10.10