### PR TITLE
Lock file

### DIFF
--- a/lib/chef/knife/solo_bootstrap.rb
+++ b/lib/chef/knife/solo_bootstrap.rb
@@ -19,7 +19,7 @@ class Chef
 
       # Use (some) options from prepare and cook commands
       self.options = SoloPrepare.options
-      [:berkshelf, :librarian, :sync_only, :why_run, :clean_up].each { |opt| option opt, SoloCook.options[opt] }
+      [:lock_file, :berkshelf, :librarian, :sync_only, :why_run, :clean_up].each { |opt| option opt, SoloCook.options[opt] }
 
       def run
         validate!

--- a/lib/chef/knife/solo_cook.rb
+++ b/lib/chef/knife/solo_cook.rb
@@ -94,7 +94,7 @@ class Chef
           lock_file = nil
           if config[:lock_file]
             ui.msg "Locking lock file '#{config[:lock_file]}'"
-            lock_file = File.open(config[:lock_file])
+            lock_file = File.open(config[:lock_file], 'a')
           end
 
           lock_file.flock(File::LOCK_EX) if lock_file

--- a/lib/chef/knife/solo_cook.rb
+++ b/lib/chef/knife/solo_cook.rb
@@ -93,8 +93,9 @@ class Chef
 
           lock_file = nil
           if config[:lock_file]
-            ui.msg "Locking lock file '#{config[:lock_file]}'"
+            ui.msg "Locking lock file '#{config[:lock_file]}'..."
             lock_file = File.open(config[:lock_file], 'a')
+            ui.msg "Lock acquired."
           end
 
           lock_file.flock(File::LOCK_EX) if lock_file

--- a/lib/chef/knife/solo_cook.rb
+++ b/lib/chef/knife/solo_cook.rb
@@ -109,7 +109,7 @@ class Chef
             generate_solorb
           end
 
-          lock_file.close() if lockfile
+          lock_file.close() if lock_file
 
           cook unless config[:sync_only]
 

--- a/lib/chef/knife/solo_prepare.rb
+++ b/lib/chef/knife/solo_prepare.rb
@@ -47,6 +47,10 @@ class Chef
           name, path = h.split("=")
           Chef::Config[:knife][:hints][name] = path ? JSON.parse(::File.read(path)) : Hash.new  }
 
+     option :lock_file,
+        :long        => '--lock-file LOCK_FILE',
+        :description => 'Lockfile path for safe parallel syncing'
+
       def run
         if config[:omnibus_version]
           ui.warn '`--omnibus-version` is deprecated, please use `--bootstrap-version`.'


### PR DESCRIPTION
This handles parallelism by setting an exclusive lock on a shared lockfile.
This fixes the issue discussed in https://github.com/matschaffer/knife-solo/issues/380 and probably https://github.com/matschaffer/knife-solo/issues/433 without any assumptions about how any dependency gems, methods, shell calls, etc. may act.

Most of the time is spent in cook() anyway. In practice (in my experience) the slowdown by having this portion be serial is minimal.
