### PR TITLE
require shell_out during test cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: ruby
+cache: bundler
 rvm:
   - 2.2.2
   - 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
   allow_failures:
     - gemfile: test/gemfiles/Gemfile.chef-master
   exclude:
+    # Chef ~> 12 depends on ohai ~> 8.0 which requires Ruby version >= 2.0.0
     - rvm: 1.9.3
       gemfile: test/gemfiles/Gemfile.chef-12
     - rvm: 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: ruby
 rvm:
   - 2.2.2

--- a/test/gemfiles/Gemfile.chef-10
+++ b/test/gemfiles/Gemfile.chef-10
@@ -6,4 +6,5 @@ gem 'chef', '~> 10'
 
 platform :ruby_19 do
   gem 'berkshelf-api-client', '~> 1.3.1'
+  gem 'varia_model', '~> 0.4.0'
 end

--- a/test/gemfiles/Gemfile.chef-10
+++ b/test/gemfiles/Gemfile.chef-10
@@ -3,3 +3,7 @@ source 'https://rubygems.org'
 gemspec :path => '../..'
 
 gem 'chef', '~> 10'
+
+platform :ruby_19 do
+  gem 'berkshelf-api-client', '~> 1.3.1'
+end

--- a/test/gemfiles/Gemfile.chef-11
+++ b/test/gemfiles/Gemfile.chef-11
@@ -3,3 +3,8 @@ source 'https://rubygems.org'
 gemspec :path => '../..'
 
 gem 'chef', '~> 11'
+
+platform :ruby_19 do
+  gem 'berkshelf-api-client', '~> 1.3.1'
+  gem 'tins', '~> 1.6.0'
+end

--- a/test/gemfiles/Gemfile.chef-11
+++ b/test/gemfiles/Gemfile.chef-11
@@ -7,4 +7,5 @@ gem 'chef', '~> 11'
 platform :ruby_19 do
   gem 'berkshelf-api-client', '~> 1.3.1'
   gem 'tins', '~> 1.6.0'
+  gem 'varia_model', '~> 0.4.0'
 end

--- a/test/support/test_case.rb
+++ b/test/support/test_case.rb
@@ -1,3 +1,8 @@
+# Normally this gets loaded by the knife application
+# but we'll require it here so we can test commands directly without getting constant missing errors.
+# See https://github.com/chef/chef/pull/4153 for updates
+require 'chef/mixin/shell_out'
+
 class TestCase < MiniTest::Unit::TestCase
   def default_test
     super unless self.class == TestCase

--- a/test/support/test_case.rb
+++ b/test/support/test_case.rb
@@ -1,8 +1,3 @@
-# Normally this gets loaded by the knife application
-# but we'll require it here so we can test commands directly without getting constant missing errors.
-# See https://github.com/chef/chef/pull/4153 for updates
-require 'chef/mixin/shell_out'
-
 class TestCase < MiniTest::Unit::TestCase
   def default_test
     super unless self.class == TestCase

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,7 @@ require 'bundler/setup'
 
 # Avoids uninitialized constant Chef::Mixin::ShellOut - see https://github.com/chef/chef/pull/4153
 require 'chef/version'
-if Gem::Requirement.new('>= 12.5.1').satisfied_by? Gem::Version.new(Chef::VERSION)
+if Gem::Requirement.new('>= 12.5.0').satisfied_by? Gem::Version.new(Chef::VERSION)
   require 'chef/mixin/shell_out'
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,12 @@
 require 'rubygems'
 require 'bundler/setup'
 
+# Avoids uninitialized constant Chef::Mixin::ShellOut - see https://github.com/chef/chef/pull/4153
+require 'chef/version'
+if Gem::Requirement.new('>= 12.5.1').satisfied_by? Gem::Version.new(Chef::VERSION)
+  require 'chef/mixin/shell_out'
+end
+
 require 'coveralls'
 Coveralls.wear!
 


### PR DESCRIPTION
This avoids a NameError when loading commands that load Knife::SSH during testing.

See https://github.com/chef/chef/pull/4153 for details on the source of the problem.