### PR TITLE
Replaced eval with const_get method

### DIFF
--- a/lib/knife-solo/bootstraps.rb
+++ b/lib/knife-solo/bootstraps.rb
@@ -16,9 +16,9 @@ module KnifeSolo
     def self.class_for_operating_system(os_name)
       begin
         os_class_name = os_name.gsub(/\s/,'')
-        eval("KnifeSolo::Bootstraps::#{os_class_name}")
+        KnifeSolo::Bootstraps.const_get(os_class_name)
       rescue
-        raise OperatingSystemNotImplementedError.new("#{os_name} not implemented.  Feel free to add a bootstrap implementation in KnifeSolo::Bootstraps::#{os_class_name}")
+        raise OperatingSystemNotImplementedError.new("#{os_name.inspect} not implemented.  Feel free to add a bootstrap implementation in KnifeSolo::Bootstraps::#{os_class_name}")
       end
     end
 


### PR DESCRIPTION
Hello @matschaffer 
when I was running `knife-solo` on one of servers I received following error:

```
Bootstrapping Chef...
ERROR: SyntaxError: (eval):1: syntax error, unexpected ':', expecting end-of-input
...Solo::Bootstraps::bash:warning:setlocale:LC_ALL:cannotchange...
...                               ^
```

I started debugging and found interesting place. In my opinion `eval` is not necessary and `const_get` is sufficient, and what's more, `const_get` helps to spot an issue way faster.

```
Bootstrapping Chef...
ERROR: KnifeSolo::Bootstraps::OperatingSystemNotImplementedError: "bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)\r\nLinux" not implemented.  Feel free to add a bootstrap implementation in KnifeSolo::Bootstraps::bash:warning:setlocale:LC_ALL:cannotchangelocale(en_US.UTF-8)Linux
```

Happy New Year :tada: 
@szemek