### PR TITLE
Use remote login user in ssh control path

### DIFF
--- a/lib/knife-solo/ssh_command.rb
+++ b/lib/knife-solo/ssh_command.rb
@@ -220,7 +220,7 @@ module KnifeSolo
     def ssh_control_path
       dir = File.join(ENV['HOME'], '.chef', 'knife-solo-sockets')
       FileUtils.mkdir_p(dir)
-      File.join(dir, '%h')
+      File.join(dir, '%r@%h:%p')
     end
 
     def custom_sudo_command


### PR DESCRIPTION
Only one user can cook a node from a single workstation when ssh
multiplexing is enabled, as it is by default, but the same control
socket is shared by multiple users.

This causes problems when bootstrapping new nodes when the initial
connection is made using the root user, but root logins are disabled
as part of the bootstrap process.

Fixed by using the remote login user name in the ssh control path.

Fixes #444