### PR TITLE
Shorten ssh control path

### DIFF
--- a/lib/knife-solo/ssh_command.rb
+++ b/lib/knife-solo/ssh_command.rb
@@ -220,7 +220,7 @@ module KnifeSolo
     def ssh_control_path
       dir = File.join(ENV['HOME'], '.chef', 'knife-solo-sockets')
       FileUtils.mkdir_p(dir)
-      File.join(dir, '%r@%h:%p')
+      File.join(dir, '%C')
     end
 
     def custom_sudo_command


### PR DESCRIPTION
My previous commit to "fix" the ssh control path by including the remote
user and port also made it more likely that the resulting path would
exceed the maximum allowed length of the path to a unix domain socket.

I've replaced the use of '%r@%h:%p' in the ssh control path with '%C',
which is substituted by a hash of the concatenation of '%l%h%p%r', so it
still includes the remote user, host and port, but is also a predictable
length and less likely to exceed the maximum allowed length of a path to
a unix domain socket (104 "chars" on OSX, 108 I think on Linux).

The change was made after I ran into a "too long for Unix domain socket"
error myself when cooking a node, and has been tested in production.