### PR TITLE
Skip any interactive post-install configuration steps when running first prepare command for Debian x86

### DIFF
--- a/lib/knife-solo/bootstraps/linux.rb
+++ b/lib/knife-solo/bootstraps/linux.rb
@@ -52,7 +52,7 @@ module KnifeSolo::Bootstraps
 
     def debianoid_omnibus_install
       run_command("sudo apt-get update")
-      run_command("sudo apt-get -y install rsync ca-certificates wget")
+      run_command("sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' --force-yes -f install rsync ca-certificates wget")
       omnibus_install
     end
 

--- a/test/gemfiles/Gemfile.chef-10
+++ b/test/gemfiles/Gemfile.chef-10
@@ -9,4 +9,5 @@ platform :ruby_19 do
   gem 'varia_model', '~> 0.4.0'
   gem 'tins', '~> 1.6.0'
   gem 'ohai', '~> 7.4.0'
+  gem 'json', '~> 1.8.1'
 end

--- a/test/gemfiles/Gemfile.chef-10
+++ b/test/gemfiles/Gemfile.chef-10
@@ -7,4 +7,6 @@ gem 'chef', '~> 10'
 platform :ruby_19 do
   gem 'berkshelf-api-client', '~> 1.3.1'
   gem 'varia_model', '~> 0.4.0'
+  gem 'tins', '~> 1.6.0'
+  gem 'ohai', '~> 7.4.0'
 end

--- a/test/gemfiles/Gemfile.chef-10
+++ b/test/gemfiles/Gemfile.chef-10
@@ -8,6 +8,7 @@ platform :ruby_19 do
   gem 'berkshelf-api-client', '~> 1.3.1'
   gem 'varia_model', '~> 0.4.0'
   gem 'tins', '~> 1.6.0'
-  gem 'ohai', '~> 7.4.0'
   gem 'json', '~> 1.8.1'
+  gem 'mixlib-config', '~> 1.1.2'
+  gem 'ohai', '~> 6.24.2'
 end

--- a/test/gemfiles/Gemfile.chef-11
+++ b/test/gemfiles/Gemfile.chef-11
@@ -8,4 +8,5 @@ platform :ruby_19 do
   gem 'berkshelf-api-client', '~> 1.3.1'
   gem 'tins', '~> 1.6.0'
   gem 'varia_model', '~> 0.4.0'
+  gem 'ohai', '~> 7.4.0'
 end

--- a/test/gemfiles/Gemfile.chef-11
+++ b/test/gemfiles/Gemfile.chef-11
@@ -8,5 +8,5 @@ platform :ruby_19 do
   gem 'berkshelf-api-client', '~> 1.3.1'
   gem 'tins', '~> 1.6.0'
   gem 'varia_model', '~> 0.4.0'
-  gem 'ohai', '~> 7.4.0'
+  gem 'ohai', '~> 7.4.1'
 end


### PR DESCRIPTION
Our vagrant os image is running as debian6.

----------------
vagrant@debian6-64:~$ uname -a
Linux debian6-64 2.6.32-5-amd64 #1 SMP Mon Sep 23 22:14:43 UTC 2013 x86_64 GNU/Linux
----------------

When I run first knife-solo prepare command, then doing apt-get installing
target host requires checking source differences and shows any interactive post-install configuration steps.
https://gist.github.com/iidatomohiko/34ac651d2191aefcfd94

So I want to skip them like debianoid_gem_install.