### PR TITLE
Removed an unsuitable package info

### DIFF
--- a/test/gemfiles/Gemfile.chef-10
+++ b/test/gemfiles/Gemfile.chef-10
@@ -7,7 +7,6 @@ gem 'chef', '~> 10'
 platform :ruby_19 do
   gem 'berkshelf-api-client', '~> 1.3.1'
   gem 'varia_model', '~> 0.4.0'
-  gem 'tins', '~> 1.6.0'
   gem 'json', '~> 1.8.1'
   gem 'mixlib-config', '~> 1.1.2'
   gem 'ohai', '~> 6.24.2'


### PR DESCRIPTION
Needless to set tins version strictly here, sorry.
I'd clean forgotten to remove before doing commit.

coveralls requires it by setting json version specifically.