### PR TITLE
Allows net-ssh v3.x

### DIFF
--- a/knife-solo.gemspec
+++ b/knife-solo.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'coveralls'
 
   s.add_dependency 'chef',     '>= 10.20'
-  s.add_dependency 'net-ssh',  '~> 2.7', '< 3.0'
+  s.add_dependency 'net-ssh',  '>= 2.7', '< 4.0'
   s.add_dependency 'erubis',   '~> 2.7.0'
 end


### PR DESCRIPTION
There is only one breaking change in v3 and it has no impact on knife-solo: https://github.com/net-ssh/net-ssh/blob/v3.0.1/CHANGES.txt#L3

This fixes one of the two issues mentioned in https://github.com/matschaffer/knife-solo/issues/478.

I've tested this locally and it seems to be working fine with the following chefdk versions:
* v0.12.0
* v0.11.2
* v0.10.0
* v0.9.0