### PR TITLE
fix regex so it is functional for 10.6 - 10.11

### DIFF
--- a/lib/knife-solo/bootstraps/darwin.rb
+++ b/lib/knife-solo/bootstraps/darwin.rb
@@ -7,7 +7,7 @@ module KnifeSolo::Bootstraps
 
     def distro
       case issue
-      when %r{10.(?:[6-9]|10)}
+      when %r{10.(?:[6-9]|1[01])}
         {:type => 'omnibus'}
       else
         raise "OS X version #{issue} not supported"


### PR DESCRIPTION
Fix "RuntimeError: OS X version 10.11.6 not supported" Error.
