### PR TITLE
Add local_mode true to knife.rb

### DIFF
--- a/lib/knife-solo/resources/knife.rb
+++ b/lib/knife-solo/resources/knife.rb
@@ -7,3 +7,4 @@ data_bag_path    "data_bags"
 
 knife[:berkshelf_path] = "cookbooks"
 Chef::Config[:ssl_verify_mode] = :verify_peer if defined? ::Chef
+local_mode       true


### PR DESCRIPTION
Without the local_mode true setting in knife.rb, the knife-solo_data_bag gem can try to access a Chef Server when showing or editing a data bag, as noted here:  https://github.com/thbishop/knife-solo_data_bag/issues/35

As noted there, setting local_mode true fixes the problem, and making it the default when using knife solo init probably makes sense.  However, I don't know enough about Chef / Knife workflow to know if adding this option could cause problems for others, especially if they are using both knife solo and Chef server from the same folder.