### PR TITLE
Add rvm 2.3.4 for integration chef ~> 13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
+  - 2.3.4
   - 2.2.2
   - 1.9.3
 gemfile:
@@ -18,4 +19,6 @@ matrix:
       gemfile: test/gemfiles/Gemfile.chef-12
     - rvm: 1.9.3
       gemfile: test/gemfiles/Gemfile.chef-master
-
+    # Chef ~> 13 requires Ruby version >= 2.3.0
+    - rvm: 2.2.2
+      gemfile: test/gemfiles/Gemfile.chef-master

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,7 @@ matrix:
     # Chef ~> 13 requires Ruby version >= 2.3.0
     - rvm: 2.2.2
       gemfile: test/gemfiles/Gemfile.chef-master
+    # Chef ~> 10 depends on json <= 1.8.1 which failed to build with
+    # Ruby 2.3.4. https://github.com/flori/json/issues/229
+    - rvm: 2.3.4
+      gemfile: test/gemfiles/Gemfile.chef-10

--- a/test/gemfiles/Gemfile.chef-10
+++ b/test/gemfiles/Gemfile.chef-10
@@ -8,7 +8,7 @@ platform :ruby_19 do
   gem 'berkshelf-api-client', '~> 1.3.1'
   gem 'tins', '~> 1.6.0'
   gem 'varia_model', '~> 0.4.0'
-  gem 'json', '~> 1.8.1'
+  gem 'json', '~> 1.8.2'
   gem 'mixlib-config', '~> 1.1.2'
   gem 'ohai', '~> 6.24.2'
   gem 'nio4r', '~> 1.2.1'

--- a/test/gemfiles/Gemfile.chef-10
+++ b/test/gemfiles/Gemfile.chef-10
@@ -8,7 +8,7 @@ platform :ruby_19 do
   gem 'berkshelf-api-client', '~> 1.3.1'
   gem 'tins', '~> 1.6.0'
   gem 'varia_model', '~> 0.4.0'
-  gem 'json', '~> 1.8.2'
+  gem 'json', '~> 1.8.1'
   gem 'mixlib-config', '~> 1.1.2'
   gem 'ohai', '~> 6.24.2'
   gem 'nio4r', '~> 1.2.1'

--- a/test/gemfiles/Gemfile.chef-master
+++ b/test/gemfiles/Gemfile.chef-master
@@ -3,3 +3,5 @@ source 'https://rubygems.org'
 gemspec :path => '../..'
 
 gem 'chef', github: 'opscode/chef'
+
+gem "ohai", github: 'chef/ohai'


### PR DESCRIPTION
Chef ~> 13 requires Ruby version >= 2.3.0, so this PR add rvm 2.3.4.
