### PR TITLE
Add a --clean-up-command option

### DIFF
--- a/lib/chef/knife/solo_clean.rb
+++ b/lib/chef/knife/solo_clean.rb
@@ -19,10 +19,14 @@ class Chef
         :description => 'Where to store kitchen data on the node'
         # TODO de-duplicate this option with solo cook
 
+      option :clean_up_command,
+        :long        => '--clean-up-command "custom command"',
+        :description => 'What command to run to remove provisioning path'
+
       def run
         validate!
         ui.msg "Cleaning up #{host}..."
-        run_command "rm -rf #{provisioning_path}"
+        run_command "#{clean_up_command} #{provisioning_path}"
       end
 
       def validate!
@@ -32,6 +36,11 @@ class Chef
       def provisioning_path
         # TODO de-duplicate this method with solo cook
         KnifeSolo::Tools.config_value(config, :provisioning_path, '~/chef-solo')
+      end
+
+      def clean_up_command
+        # TODO de-duplicate this method with solo cook
+        KnifeSolo::Tools.config_value(config, :clean_up_command, 'rm -rf')
       end
     end
   end

--- a/lib/chef/knife/solo_cook.rb
+++ b/lib/chef/knife/solo_cook.rb
@@ -75,6 +75,10 @@ class Chef
         :long        => '--clean-up',
         :description => 'Run the clean command after cooking'
 
+      option :clean_up_command,
+        :long        => '--clean-up-command',
+        :description => 'What command to use for clean up'
+
       option :legacy_mode,
         :long        => '--legacy-mode',
         :description => 'Run chef-solo in legacy mode'
@@ -118,6 +122,11 @@ class Chef
       def provisioning_path
         # TODO ~ will likely break on cmd.exe based windows sessions
         config_value(:provisioning_path, '~/chef-solo')
+      end
+
+      def clean_up_command
+        # TODO ~ will likely break on cmd.exe based windows sessions
+        config_value(:clean_up_command, 'rm -rf')
       end
 
       def sync_kitchen

--- a/test/solo_clean_test.rb
+++ b/test/solo_clean_test.rb
@@ -13,8 +13,8 @@ class SoloCleanTest < TestCase
   end
 
   def test_removes_provision_path_with_custom_command
-    cmd = command('somehost', '--clean-up-command "sudo rm -rf"')
-    cmd.expects(:run_command).with('sudo rm -rf ~/chef-solo').returns(SuccessfulResult.new)
+    cmd = command('somehost', '--clean-up-command=echo')
+    cmd.expects(:run_command).with('echo ~/chef-solo').returns(SuccessfulResult.new)
     cmd.run
   end
 

--- a/test/solo_clean_test.rb
+++ b/test/solo_clean_test.rb
@@ -12,6 +12,12 @@ class SoloCleanTest < TestCase
     cmd.run
   end
 
+  def test_removes_provision_path_with_custom_command
+    cmd = command('somehost', '--cleanup-command="sudo rm -rf"')
+    cmd.expects(:run_command).with('sudo rm -rf ~/chef-solo').returns(SuccessfulResult.new)
+    cmd.run
+  end
+
   def command(*args)
     knife_command(Chef::Knife::SoloClean, *args)
   end

--- a/test/solo_clean_test.rb
+++ b/test/solo_clean_test.rb
@@ -13,7 +13,7 @@ class SoloCleanTest < TestCase
   end
 
   def test_removes_provision_path_with_custom_command
-    cmd = command('somehost', '--cleanup-command="sudo rm -rf"')
+    cmd = command('somehost', '--clean-up-command "sudo rm -rf"')
     cmd.expects(:run_command).with('sudo rm -rf ~/chef-solo').returns(SuccessfulResult.new)
     cmd.run
   end


### PR DESCRIPTION
- Add option to specify alternative to `rm -rf` for clean_up
- Add test for specifying --cleanup-command
- Add clean_up_command to solo cook

### Use Case

If you run chef in `local_mode`, we end up finding our local `chef-solo` directory has its local cache populated with files owned by root. So the `knife solo clean` fails silently on permission denied removing those files. This allows you to override the `rm -rf` with your own command, in our case `sudo rm -rf`

Some examples from running `knife solo clean` with `-VV`
```
rm: cannot remove ‘/home/ubuntu/chef-solo/local-mode-cache/cache/cookbooks/rsyslog/resources’: Permission denied
rm: cannot remove ‘/home/ubuntu/chef-solo/local-mode-cache/cache/cookbooks/ohai/recipes/default.rb’: Permission denied
rm: cannot remove ‘/home/ubuntu/chef-solo/local-mode-cache/cache/cookbooks/ohai/libraries/matchers.rb’: Permission denied
rm: cannot remove ‘/home/ubuntu/chef-solo/local-mode-cache/cache/cookbooks/ohai/attributes’: Permission denied
rm: cannot remove ‘/home/ubuntu/chef-solo/local-mode-cache/cache/cookbooks/ohai/providers’: Permission denied
```
