### PR TITLE
Uses sudo when running clean

### DIFF
--- a/lib/chef/knife/solo_clean.rb
+++ b/lib/chef/knife/solo_clean.rb
@@ -22,7 +22,7 @@ class Chef
       def run
         validate!
         ui.msg "Cleaning up #{host}..."
-        run_command "rm -rf #{provisioning_path}"
+        run_command "#{sudo_command} rm -rf #{provisioning_path}"
       end
 
       def validate!
@@ -32,6 +32,10 @@ class Chef
       def provisioning_path
         # TODO de-duplicate this method with solo cook
         KnifeSolo::Tools.config_value(config, :provisioning_path, '~/chef-solo')
+      end
+
+      def sudo_command
+        KnifeSolo::Tools.config_value(config, :sudo_command, 'sudo')
       end
     end
   end

--- a/test/solo_clean_test.rb
+++ b/test/solo_clean_test.rb
@@ -8,7 +8,13 @@ class SoloCleanTest < TestCase
 
   def test_removes_provision_path
     cmd = command('somehost', '--provisioning-path=/foo/bar')
-    cmd.expects(:run_command).with('rm -rf /foo/bar').returns(SuccessfulResult.new)
+    cmd.expects(:run_command).with('sudo rm -rf /foo/bar').returns(SuccessfulResult.new)
+    cmd.run
+  end
+
+  def test_removes_with_custom_sudo
+    cmd = command('somehost', '--sudo-command=/usr/some/sudo')
+    cmd.expects(:run_command).with('/usr/some/sudo rm -rf ~/chef-solo').returns(SuccessfulResult.new)
     cmd.run
   end
 


### PR DESCRIPTION
Following up on a request in #518, this simplifies cleaning to always run sudo [per the recommendation in this comment](https://github.com/matschaffer/knife-solo/pull/518#issuecomment-322018301).

Happy to improve this with any feedback as well.