### PR TITLE
Fixed solo clean command and made log level configurable

### DIFF
--- a/lib/chef/knife/solo_clean.rb
+++ b/lib/chef/knife/solo_clean.rb
@@ -22,7 +22,7 @@ class Chef
       def run
         validate!
         ui.msg "Cleaning up #{host}..."
-        run_command "#{sudo_command} rm -rf #{provisioning_path}"
+        run_command "sudo rm -rf #{provisioning_path}"
       end
 
       def validate!
@@ -32,10 +32,6 @@ class Chef
       def provisioning_path
         # TODO de-duplicate this method with solo cook
         KnifeSolo::Tools.config_value(config, :provisioning_path, '~/chef-solo')
-      end
-
-      def sudo_command
-        KnifeSolo::Tools.config_value(config, :sudo_command, 'sudo')
       end
     end
   end

--- a/lib/chef/knife/solo_cook.rb
+++ b/lib/chef/knife/solo_cook.rb
@@ -143,6 +143,10 @@ class Chef
         Chef::Config[:solo_legacy_mode] || false
       end
 
+      def log_level
+        Chef::Config[:log_level] || :warn
+      end
+
       def expand_path(path)
         Pathname.new(path).expand_path
       end

--- a/lib/chef/knife/solo_cook.rb
+++ b/lib/chef/knife/solo_cook.rb
@@ -79,6 +79,11 @@ class Chef
         :long        => '--legacy-mode',
         :description => 'Run chef-solo in legacy mode'
 
+      option :log_level,
+        :short       => '-l LEVEL',
+        :long        => '--log-level',
+        :description => 'Set the log level for Chef'
+
       def run
         time('Run') do
 
@@ -144,7 +149,11 @@ class Chef
       end
 
       def log_level
-        Chef::Config[:log_level] || :warn
+        config_value(:log_level, Chef::Config[:log_level] || :warn).to_sym
+      end
+
+      def enable_reporting
+        config_value(:enable_reporting, true)
       end
 
       def expand_path(path)

--- a/lib/knife-solo/resources/solo.rb.erb
+++ b/lib/knife-solo/resources/solo.rb.erb
@@ -11,6 +11,7 @@ environment               <%= node_environment.inspect %>
 ssl_verify_mode           <%= ssl_verify_mode.inspect %>
 solo_legacy_mode          <%= solo_legacy_mode.inspect %>
 log_level                 <%= log_level.inspect %>
+enable_reporting          <%= enable_reporting.inspect %>
 
 cookbook_path []
 <% cookbook_paths.each_with_index do |path, i| -%>

--- a/lib/knife-solo/resources/solo.rb.erb
+++ b/lib/knife-solo/resources/solo.rb.erb
@@ -10,6 +10,7 @@ environment_path          File.join(base, 'environments')
 environment               <%= node_environment.inspect %>
 ssl_verify_mode           <%= ssl_verify_mode.inspect %>
 solo_legacy_mode          <%= solo_legacy_mode.inspect %>
+log_level                 <%= log_level.inspect %>
 
 cookbook_path []
 <% cookbook_paths.each_with_index do |path, i| -%>

--- a/lib/knife-solo/ssh_command.rb
+++ b/lib/knife-solo/ssh_command.rb
@@ -296,7 +296,6 @@ module KnifeSolo
 
       output = ui.stdout if options[:streaming]
 
-
       @connection ||= ssh_connection
       @connection.run_command(command, output)
     end

--- a/test/solo_clean_test.rb
+++ b/test/solo_clean_test.rb
@@ -6,15 +6,15 @@ require 'chef/knife/solo_clean'
 class SoloCleanTest < TestCase
   include ValidationHelper::ValidationTests
 
-  def test_removes_provision_path
-    cmd = command('somehost', '--provisioning-path=/foo/bar')
-    cmd.expects(:run_command).with('sudo rm -rf /foo/bar').returns(SuccessfulResult.new)
+  def test_removes_default_directory
+    cmd = command('somehost')
+    cmd.expects(:run_command).with('sudo rm -rf ~/chef-solo').returns(SuccessfulResult.new)
     cmd.run
   end
 
-  def test_removes_with_custom_sudo
-    cmd = command('somehost', '--sudo-command=/usr/some/sudo')
-    cmd.expects(:run_command).with('/usr/some/sudo rm -rf ~/chef-solo').returns(SuccessfulResult.new)
+  def test_removes_provision_path
+    cmd = command('somehost', '--provisioning-path=/foo/bar')
+    cmd.expects(:run_command).with('sudo rm -rf /foo/bar').returns(SuccessfulResult.new)
     cmd.run
   end
 


### PR DESCRIPTION
The `solo clean` command did not work for me. It always generated this command:
`sudo -p \'knife sudo password: \' -p \'knife sudo password: \' rm -rf`

This is because `KnifeSolo::SshCommand` is calling `#process_sudo` which is replacing "sudo" with the `sudo_command`. But in this case `sudo_command` was already present in the command.
So i removed this from the Clean-Command and just used "sudo" like in the Cook-Command.

Also the log level for my Cook runs defaulted to debug and generated a lot of output. I added an option to change it and defaulted it to the Chef-Log-Level.

I also made `enable_reporting` configurable through the `solo.rb` file.