### PR TITLE
Quote file paths for ssh

### DIFF
--- a/lib/knife-solo/ssh_command.rb
+++ b/lib/knife-solo/ssh_command.rb
@@ -206,11 +206,11 @@ module KnifeSolo
 
       args << [user, host].compact.join('@')
 
-      args << "-F #{config[:ssh_config]}" if config[:ssh_config]
-      args << "-i #{identity_file}" if identity_file
+      args << "-F \"#{config[:ssh_config]}\"" if config[:ssh_config]
+      args << "-i \"#{identity_file}\"" if identity_file
       args << "-o ForwardAgent=yes" if config[:forward_agent]
       args << "-p #{config[:ssh_port]}" if config[:ssh_port]
-      args << "-o UserKnownHostsFile=#{connection_options[:user_known_hosts_file]}" if config[:host_key_verify] == false
+      args << "-o UserKnownHostsFile=\"#{connection_options[:user_known_hosts_file]}\"" if config[:host_key_verify] == false
       args << "-o StrictHostKeyChecking=no" if config[:host_key_verify] == false
       args << "-o ControlMaster=auto -o ControlPath=#{ssh_control_path} -o ControlPersist=3600" unless config[:ssh_control_master] == "no"
 

--- a/test/ssh_command_test.rb
+++ b/test/ssh_command_test.rb
@@ -134,15 +134,15 @@ class SshCommandTest < TestCase
 
     cmd = command("usertest@10.0.0.1", "--ssh-config-file=myconfig")
     cmd.validate_ssh_options!
-    assert_equal "usertest@10.0.0.1 -F myconfig", cmd.ssh_args
+    assert_equal "usertest@10.0.0.1 -F \"myconfig\"", cmd.ssh_args
 
     cmd = command("usertest@10.0.0.1", "--ssh-identity=my_rsa")
     cmd.validate_ssh_options!
-    assert_equal "usertest@10.0.0.1 -i my_rsa", cmd.ssh_args
+    assert_equal "usertest@10.0.0.1 -i \"my_rsa\"", cmd.ssh_args
 
     cmd = command("usertest@10.0.0.1", "--identity-file=my_rsa")
     cmd.validate_ssh_options!
-    assert_equal "usertest@10.0.0.1 -i my_rsa", cmd.ssh_args
+    assert_equal "usertest@10.0.0.1 -i \"my_rsa\"", cmd.ssh_args
 
     cmd = command("usertest@10.0.0.1", "--ssh-port=222")
     cmd.validate_ssh_options!
@@ -150,7 +150,7 @@ class SshCommandTest < TestCase
 
     cmd = command("usertest@10.0.0.1", "--no-host-key-verify")
     cmd.validate_ssh_options!
-    assert_equal "usertest@10.0.0.1 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no", cmd.ssh_args
+    assert_equal "usertest@10.0.0.1 -o UserKnownHostsFile=\"/dev/null\" -o StrictHostKeyChecking=no", cmd.ssh_args
 
     cmd = command("usertest@10.0.0.1", "--forward-agent")
     cmd.validate_ssh_options!


### PR DESCRIPTION
This fixes #525, as well as some other file quoting issues that likely would have arisen for other command line options.