### PR TITLE
Net::SSH - Deprecation warning for option :paranoid

### DIFF
--- a/lib/knife-solo/ssh_command.rb
+++ b/lib/knife-solo/ssh_command.rb
@@ -1,11 +1,18 @@
 module KnifeSolo
   module SshCommand
-
     def self.load_deps
       require 'knife-solo/ssh_connection'
       require 'knife-solo/tools'
       require 'net/ssh'
       require 'net/ssh/gateway'
+    end
+
+    def self.verify_option_key
+      @verify_option_key ||= if Net::SSH::VALID_OPTIONS.include? :verify_host_key
+        :verify_host_key
+      else
+        :paranoid
+      end
     end
 
     def self.included(other)
@@ -171,7 +178,7 @@ module KnifeSolo
       options[:gateway] = config[:ssh_gateway] if config[:ssh_gateway]
       options[:forward_agent] = true if config[:forward_agent]
       if !config[:host_key_verify]
-        options[:paranoid] = false
+        options[KnifeSolo::SshCommand.verify_option_key] = false
         options[:user_known_hosts_file] = "/dev/null"
       end
       if config[:ssh_keepalive]

--- a/test/ssh_command_test.rb
+++ b/test/ssh_command_test.rb
@@ -104,7 +104,7 @@ class SshCommandTest < TestCase
 
   def test_handle_no_host_key_verify
     cmd = command("10.0.0.1", "--no-host-key-verify")
-    assert_equal false,  cmd.connection_options[:paranoid]
+    assert_equal false,  cmd.connection_options[KnifeSolo::SshCommand.verify_option_key]
     assert_equal "/dev/null",  cmd.connection_options[:user_known_hosts_file]
   end
 
@@ -122,7 +122,7 @@ class SshCommandTest < TestCase
 
   def test_handle_default_host_key_verify_is_paranoid
     cmd = command("10.0.0.1")
-    assert_nil(cmd.connection_options[:paranoid]) # Net:SSH default is :paranoid => true
+    assert_nil(cmd.connection_options[KnifeSolo::SshCommand.verify_option_key]) # Net:SSH default is (:paranoid or :verify_host_key) => true
     assert_nil(cmd.connection_options[:user_known_hosts_file])
   end
 


### PR DESCRIPTION
since Net::SSH version 4.2.0:

:paranoid is deprecated, please use :verify_host_key. Supported Both :paranoid and :verify_host_key were specified.  :verify_host_key takes precedence, :paranoid will be ignored.

This change removes the deprecation warning for the current Net::SSH version and supports older versions of Net::SSH, too.