### PR TITLE
Use new supermarket API URL for librarian

### DIFF
--- a/lib/knife-solo/librarian.rb
+++ b/lib/knife-solo/librarian.rb
@@ -28,7 +28,7 @@ module KnifeSolo
     end
 
     def initial_config
-      "site 'http://supermarket.getchef.com/api/v1'"
+      "site 'https://supermarket.chef.io/api/v1'"
     end
 
     # Returns an array of strings to gitignore when bootstrapping


### PR DESCRIPTION
In my case, for some reason the old URL didn't work at all anymore. But I couldn't find any info if it has been turned off.

Anyway, this is the new URL anyway and I've tested locally that this works. :)