### PR TITLE
Make `check_chef_version` configurable via knife.rb

### DIFF
--- a/lib/chef/knife/solo_cook.rb
+++ b/lib/chef/knife/solo_cook.rb
@@ -302,8 +302,9 @@ class Chef
 
       def check_chef_version
         ui.msg "Checking Chef version..."
-        unless chef_version_satisfies? CHEF_VERSION_CONSTRAINT
-          raise "Couldn't find Chef #{CHEF_VERSION_CONSTRAINT} on #{host}. Please run `knife solo prepare #{ssh_args}` to ensure Chef is installed and up to date."
+        version = Chef::Config[:knife][:solo_chef_version] || CHEF_VERSION_CONSTRAINT
+        unless chef_version_satisfies?(version)
+          raise "Couldn't find Chef #{version} on #{host}. Please run `knife solo prepare #{ssh_args}` to ensure Chef is installed and up to date."
         end
         if node_environment != '_default' && chef_version_satisfies?('<11.6.0')
           ui.warn "Chef version #{chef_version} does not support environments. Environment '#{node_environment}' will be ignored."

--- a/lib/chef/knife/solo_cook.rb
+++ b/lib/chef/knife/solo_cook.rb
@@ -9,7 +9,6 @@ class Chef
     # Approach ported from spatula (https://github.com/trotter/spatula)
     # Copyright 2009, Trotter Cashion
     class SoloCook < Knife
-      CHEF_VERSION_CONSTRAINT    = ">=0.10.4" unless defined? CHEF_VERSION_CONSTRAINT
 
       include KnifeSolo::SshCommand
       include KnifeSolo::NodeConfigCommand
@@ -146,6 +145,10 @@ class Chef
 
       def solo_legacy_mode
         Chef::Config[:solo_legacy_mode] || false
+      end
+
+      def chef_version_constraint
+        Chef::Config[:solo_chef_version] || ">=0.10.4"
       end
 
       def log_level
@@ -302,9 +305,8 @@ class Chef
 
       def check_chef_version
         ui.msg "Checking Chef version..."
-        version = Chef::Config[:knife][:solo_chef_version] || CHEF_VERSION_CONSTRAINT
-        unless chef_version_satisfies?(version)
-          raise "Couldn't find Chef #{version} on #{host}. Please run `knife solo prepare #{ssh_args}` to ensure Chef is installed and up to date."
+        unless chef_version_satisfies?(chef_version_constraint)
+          raise "Couldn't find Chef #{chef_version_constraint} on #{host}. Please run `knife solo prepare #{ssh_args}` to ensure Chef is installed and up to date."
         end
         if node_environment != '_default' && chef_version_satisfies?('<11.6.0')
           ui.warn "Chef version #{chef_version} does not support environments. Environment '#{node_environment}' will be ignored."


### PR DESCRIPTION
### changes

Updates `SoloCook#check_chef_version` to now check `knife.rb` for a key `:solo_chef_version` which specifies the version constraint required. We need this as a way to bail out of a Chef run with better error messages. The current constraint of `>=0.10.4` is satisfied by the Vagrant box we're using (phusion 14.04) but we have cookbooks that require Chef 12 -- we get around this by requiring `knife solo prepare` to run before `knife solo cook`. However, sometimes people forget to run it and encounter the following error because we have cookbooks w/ `metadata.rb`'s that are updated for Chef 12:

```
[2018-08-31T23:28:09+00:00] ERROR: undefined method `source_url' for #<Chef::Cookbook::Metadata:0x000000032361f0>
[2018-08-31T23:28:09+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
```

They then message an ops person because it looks like something broke when really they just need to run `knife solo prepare`.

### testing

```
# without knife[:solo_chef_version] defined
➜ tail -1 ~/.chef/knife.rb
#knife[:solo_chef_version] = '>= 12.0.0'
➜ knife solo cook test.local nodes/test.local.json
Running Chef on test.local...
Checking Chef version...
chef_version_satisfies?(>=0.10.4) # this was debug output from me
Installing Berkshelf cookbooks to 'cookbooks'...
.... output ...
Running Chef: sudo chef-solo -c ~/chef-solo/solo.rb -j ~/chef-solo/dna.json
Starting Chef Client, version 11.12.2

Running handlers:
[2018-08-31T23:28:55+00:00] ERROR: Running exception handlers
Running handlers complete

[2018-08-31T23:28:55+00:00] ERROR: Exception handlers complete
[2018-08-31T23:28:55+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
Chef Client failed. 0 resources updated in 1.851528323 seconds
[2018-08-31T23:28:55+00:00] ERROR: undefined method `source_url' for #<Chef::Cookbook::Metadata:0x00000004699ca0>
[2018-08-31T23:28:55+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
ERROR: RuntimeError: chef-solo failed. See output above.
```

vs with the new option added to `knife.rb`

```
➜ tail -1 ~/.chef/knife.rb
knife[:solo_chef_version] = '>= 12.0.0'
➜ knife solo cook test.local nodes/test.local.json
Running Chef on test.local...
Checking Chef version...
ERROR: RuntimeError: Couldn't find Chef >= 12.0.0 on apollo.local. Please run `knife solo prepare isaacboehman@test.local -o ForwardAgent=yes` to ensure Chef is installed and up to date.
```