### PR TITLE
Parse version with "Chef Infra Client: x.y.z" format

### DIFF
--- a/lib/chef/knife/solo_cook.rb
+++ b/lib/chef/knife/solo_cook.rb
@@ -317,11 +317,11 @@ class Chef
         Gem::Requirement.new(requirement).satisfied_by? Gem::Version.new(chef_version)
       end
 
-      # Parses "Chef: x.y.z" from the chef-solo version output
+      # Parses "Chef: x.y.z" and "Chef Infra Client: x.y.z" from the chef-solo version output
       def chef_version
         # Memoize the version to avoid multiple SSH calls
         @chef_version ||= lambda do
-          cmd = %q{sudo chef-solo --version 2>/dev/null | awk '$1 == "Chef:" {print $2}'}
+          cmd = %q{sudo chef-solo --version 2>/dev/null | awk -F ": " '/Chef/{print $2}'}
           run_command(cmd).stdout.strip
         end.call
       end


### PR DESCRIPTION
chef-solo --version returns, with current version, a string like "Chef Infra Client: x.y.z".
It was "Chef: x.y.z" before.
For example:  
"Chef: 14.7.17"   and "Chef Infra Client: 15.10.12"